### PR TITLE
fix(containers): manage rundeck admin password via IaC + drop broken metrics scrape

### DIFF
--- a/terraform/portainer/locals.tf
+++ b/terraform/portainer/locals.tf
@@ -363,25 +363,16 @@ locals {
             labels:
               instance: pihole-3
 
-      # ── Phase 3f: Rundeck native /metrics endpoint ──────────────────
-      # Scrape directly at the rundeck container IP (192.168.59.22:4440)
-      # to avoid going through nginx-rproxy for an internal-only metric.
-      # Bearer token comes from a dedicated read-only Rundeck API token
-      # (Vault: secret/homelab/rundeck, field api_token), rendered to
-      # /etc/prometheus/tokens/rundeck_api via docker `configs:` (see
-      # prometheus.yml.tftpl). Same wiring pattern as ha_token /
-      # watchtower_token; will migrate to a Vault-agent sidecar when
-      # the shared template-renderer pattern lands.
-      - job_name: rundeck
-        scrape_interval: 60s
-        metrics_path: /api/40/metrics/metrics
-        bearer_token_file: /etc/prometheus/tokens/rundeck_api
-        static_configs:
-          - targets: ['192.168.59.22:4440']
-            labels:
-              instance: rundeck-1
-
-      # ── Phase 3f: Twingate (no scrape — see note) ───────────────────
+      # ── Phase 3f: Rundeck (no scrape — see note) ────────────────────
+      # Rundeck OSS 5.x exposes Dropwizard metrics at /metrics/metrics
+      # but gates that endpoint behind session-cookie auth — it does
+      # NOT accept the API bearer token. The /api/<v>/metrics/metrics
+      # path that older Rundeck versions used returns 404. So our
+      # original `bearer_token_file` scrape can't be made to work
+      # without installing the third-party rundeck-prometheus-plugin.
+      # Coverage gap is small: blackbox-tcp already probes :4440 for
+      # liveness, and the API token (Vault `api_token`) is preserved
+      # for ad-hoc CLI use. Re-enable this job once the plugin lands.
       # The connector exposes /metrics natively (TWINGATE_METRICS_PORT
       # set in twingate-a.yml / twingate-b.yml) but binds [::]:9999 and
       # our macvlan has IPv6 fully unloaded, so the listener never
@@ -673,18 +664,7 @@ locals {
             labels:
               instance: pihole-3
 
-      # ── Phase 3f: Rundeck native /metrics ───────────────────────────
-      # Mirror of replica-A job. See replica-A comment for context.
-      - job_name: rundeck
-        scrape_interval: 60s
-        metrics_path: /api/40/metrics/metrics
-        bearer_token_file: /etc/prometheus/tokens/rundeck_api
-        static_configs:
-          - targets: ['192.168.59.22:4440']
-            labels:
-              instance: rundeck-1
-
-      # ── Phase 3f: Twingate (no scrape — see replica-A note) ─────────
+      # ── Phase 3f: Rundeck (no scrape — see replica-A note) ──────────
 
       # ── Phase 3f: blackbox TCP probes ───────────────────────────────
       # Mirror of replica-A job. See replica-A comment for context.

--- a/terraform/portainer/stacks.tf
+++ b/terraform/portainer/stacks.tf
@@ -267,7 +267,20 @@ resource "portainer_stack" "rundeck" {
   deployment_type = "standalone"
   method          = "string"
 
-  stack_file_content = file("${path.module}/stacks/rundeck.yml")
+  stack_file_content = templatefile("${path.module}/stacks/rundeck.yml.tftpl", {
+    # admin user line for realm.properties: MD5-hashed password from
+    # Vault followed by the role list. Cleartext stays in Vault as
+    # `admin_password` for ops reference; bcrypt hash also kept in
+    # Vault as `admin_password_bcrypt` for the day we either build
+    # realm.properties into the rundeck image or land a bind-mount
+    # mechanism that doesn't traverse Compose's `$` interpolation.
+    # MD5 is cryptographically weaker than bcrypt but Jetty's
+    # PropertyFileLoginModule supports it natively, the format
+    # contains no `$` characters (so it survives Portainer + Compose
+    # interpolation), and it's still one-way — strictly better than
+    # the upstream default of plaintext `admin:admin`.
+    realm_admin_line = "${data.vault_kv_secret_v2.rundeck.data["admin_password_md5"]},user,admin"
+  })
 
   env {
     name  = "RUNDECK_DB_PASSWORD"

--- a/terraform/portainer/stacks/rundeck.yml.tftpl
+++ b/terraform/portainer/stacks/rundeck.yml.tftpl
@@ -1,9 +1,26 @@
 name: la-rundeck
 
+# realm.properties is the source of truth for Rundeck UI auth — Jetty
+# PropertyFileLoginModule reads it. Default container ships an
+# admin:admin entry; we override with a bcrypt-hashed password
+# rendered from Vault (`secret/homelab/rundeck`, key
+# `admin_password_bcrypt`). Cleartext stays in Vault as `admin_password`
+# for ops reference. The DataSourceLoginModule env vars from the
+# original config were silent no-ops (Rundeck OSS doesn't ship that
+# class) and have been removed.
+
 networks:
   servers-net:
     name: docker-servers-net
     external: true
+
+configs:
+  realm_properties:
+    content: |
+      # Managed by Terraform — do not edit on host.
+      # Format: <username>: <password>[,<role>...]
+      admin: ${realm_admin_line}
+      user: user,user
 
 services:
   rundeck:
@@ -15,18 +32,14 @@ services:
       RUNDECK_SERVER_UUID: 2356DEE1-1A12-463C-8ABB-D6A9F44161B4
       RUNDECK_DATABASE_DRIVER: org.postgresql.Driver
       RUNDECK_DATABASE_USERNAME: rundeck
-      RUNDECK_DATABASE_PASSWORD: ${RUNDECK_DB_PASSWORD}
+      RUNDECK_DATABASE_PASSWORD: $${RUNDECK_DB_PASSWORD}
       RUNDECK_DATABASE_URL: jdbc:postgresql://postgres-rundeck/rundeck?autoReconnect=true&useSSL=false&allowPublicKeyRetrieval=true
       RUNDECK_GRAILS_URL: https://rundeck.d.lcamaral.com
       RUNDECK_SERVER_FORWARDED: true
-      RUNDECK_STORAGE_CONVERTER_1_CONFIG_PASSWORD: ${RUNDECK_STORAGE_PASSWORD}
-      RUNDECK_CONFIG_STORAGE_CONVERTER_1_CONFIG_PASSWORD: ${RUNDECK_STORAGE_PASSWORD}
+      RUNDECK_STORAGE_CONVERTER_1_CONFIG_PASSWORD: $${RUNDECK_STORAGE_PASSWORD}
+      RUNDECK_CONFIG_STORAGE_CONVERTER_1_CONFIG_PASSWORD: $${RUNDECK_STORAGE_PASSWORD}
       RUNDECK_PASSWORD_RESET_ENABLED: true
       RUNDECK_SECURITY_USEJAAS: true
-      RUNDECK_JAAS_LOGINMODULE_NAME: rundeckdb
-      RUNDECK_JAAS_LOGINMODULE_CONF_RUNDECKDB_0: org.rundeck.jaas.jetty.DataSourceLoginModule required
-      RUNDECK_JAAS_LOGINMODULE_CONF_RUNDECKDB_1: debug="true"
-      RUNDECK_JAAS_LOGINMODULE_CONF_RUNDECKDB_2: dataSourceName="dataSource"
     restart: always
     expose:
       - 4440
@@ -37,6 +50,10 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - /nfs/dockermaster/docker/rundeck/data:/home/rundeck/server/data
       - /nfs/dockermaster/docker/rundeck/container-plugins:/home/rundeck/container-plugins
+    configs:
+      - source: realm_properties
+        target: /home/rundeck/server/config/realm.properties
+        mode: 0644
     depends_on:
       postgres:
         condition: service_healthy
@@ -65,7 +82,7 @@ services:
     environment:
       POSTGRES_DB: rundeck
       POSTGRES_USER: rundeck
-      POSTGRES_PASSWORD: ${RUNDECK_DB_PASSWORD}
+      POSTGRES_PASSWORD: $${RUNDECK_DB_PASSWORD}
     volumes:
       - /nfs/dockermaster/docker/rundeck/dbdata:/var/lib/postgresql/data
     healthcheck:


### PR DESCRIPTION
## Summary

Two related Rundeck closeout items found during Phase 3 wrap-up.

## What changed

**1. Admin password is now IaC-managed via realm.properties**
- Was the upstream-shipped default `admin:admin`. The earlier `RUNDECK_JAAS_LOGINMODULE_*` env vars in this stack were silent no-ops — Rundeck OSS doesn't ship `org.rundeck.jaas.jetty.DataSourceLoginModule`, so the Jetty `PropertyFileLoginModule` fell back to the default realm.properties.
- Now `realm.properties` is rendered from Terraform `templatefile()` into a Compose `configs:` block. Admin password line: `MD5:<hash>` from Vault `secret/homelab/rundeck` field `admin_password_md5`.
- Cleartext stays in Vault as `admin_password` for ops reference; bcrypt is also kept as `admin_password_bcrypt` for the day we land a deployment path that doesn't traverse Compose's `$` interpolation (4×-escape `replace($, $$$$)` was tried; both Portainer and Compose ate `$` characters in the bcrypt salt). MD5 is one-way and IaC-deterministic — strictly better than the upstream default.

**2. Rundeck scrape job removed from prom config**
- `/api/<v>/metrics/metrics` returns 404 in Rundeck OSS 5.x; the path moved to `/metrics/metrics` (Dropwizard) and is now gated by session-cookie auth, not bearer token. The `bearer_token_file` scrape can't be made to work without installing the third-party `rundeck-prometheus-plugin`.
- Coverage gap is small: blackbox-tcp already probes `:4440` for liveness, and the API token (Vault `api_token`) is preserved for ad-hoc CLI use.

## Verification

- `terraform apply` clean (1 stack updated for rundeck, 2 for prom-1/-2 config rebuild).
- realm.properties inside container: `admin: MD5:f9584242a577cd72833d302289d2b672,user,admin` ✓
- Form-POST `j_username=admin & j_password=Saturno#1220rd` to `/j_security_check` → 302 → `/menu/home` → 200.
- Rundeck `up{job=rundeck}` series gone; targets total dropped 64 → 63 (clean).

## Backlog (not in scope)

- pihole-1/-2 401 auth-failure spam (pre-existing, likely Pi-hole v6 rate-limit; pihole-3 fine).
- snmp-pfsense down (pfSense SNMP daemon config; deferred).
- Bcrypt-via-IaC for realm.properties (need rundeck-prometheus-plugin or image-baked file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)