### PR TITLE
docs(monitoring): macvlan flakiness was pihole v5/v6 exporter mismatch

### DIFF
--- a/rundeck/jobs/pihole-auth-check.yaml
+++ b/rundeck/jobs/pihole-auth-check.yaml
@@ -69,7 +69,12 @@
   options:
     - name: NOTES
       value: |
-        Background: 2026-04-28 wrap-up flagged pihole-1/-2 401 auth-failure
-        spam with pihole-3 still healthy. Likely Pi-hole v6 rate-limit
-        which clears in 30 minutes. This 2-week follow-up confirms
-        recovery. If still failing, dig into pihole-1 LXC logs.
+        Updated 2026-04-28: ROOT CAUSE identified during the macvlan
+        diagnostic branch. ekofr/pihole-exporter:v1.2.0 is v5-only and
+        all three Pi-hole instances are v6 — the exporter hangs its
+        HTTP server in a retry loop against /admin/api.php which v6
+        returns 400 on. Pihole-exporter-3 appeared to work because it
+        served stale cached values. Real fix: swap exporter to
+        bazmonk/pihole6_exporter (separate workstream). This job will
+        keep failing until the swap lands; flip executionEnabled to
+        false at that point or delete the job entirely.


### PR DESCRIPTION
## TL;DR

Branch opened to fix \"macvlan inter-host flakiness\" discovered during the Rundeck job test run on 2026-04-28. **Network was never the problem.** The actual root cause is `ekofr/pihole-exporter:v1.2.0` being Pi-hole v5 only while all three homelab Pi-holes run v6.

## Diagnostic chain

| Layer | Test | Result |
|---|---|---|
| ICMP | dockermaster → 192.168.59.41 | ✅ replies in ~0.1ms |
| ICMP | dockermaster → 192.168.59.42 | ✅ replies in ~0.5ms |
| TCP | `</dev/tcp/192.168.59.41/9617` | ✅ exit 0 (handshake succeeds) |
| HTTP | `curl -v http://192.168.59.41:9617/metrics` | ❌ TCP connect, then 0 bytes received, timeout |
| In-container | `nsenter -t <pid> -n ss -tlnp` | ✅ pihole-exporter listening on 0.0.0.0:9617 |
| Upstream | `curl http://192.168.100.254/admin/api.php` (Pi-hole v5 endpoint) | ❌ HTTP 400 \"Bad request, the API is hosted at pi.hole/api\" |
| Image age | ekofr/pihole-exporter:v1.2.0 | v5 only |
| Pi-hole versions | pihole-1/-2/-3 | All v6 (Core 6.4+) |

## Why pihole-exporter-3 looked OK

It serves cached numbers from prior successful scrapes (or zero-init defaults). The metric values look plausible but are not fresh. Future Phase 4 dashboards using `rate()` will flag this as flatlines.

## Real fix (NOT in this PR)

Swap `ekofr/pihole-exporter:v1.2.0` → either [bazmonk/pihole6_exporter](https://github.com/bazmonk/pihole6_exporter) (v6-native, community) or wait for upstream `eko/pihole-exporter` v2.x. That's a separate workstream.

## What this PR does

- Updates the `pihole-auth-check` Rundeck job NOTES so when it fires on 2026-05-12 the operator knows the real root cause without re-doing this diagnostic walk.
- Adds project memory `feedback_pihole_v6_exporter_incompat.md` so future \"macvlan inter-host flakiness\" symptoms get triaged at the right layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)