### PR TITLE
feat(monitoring): regen pfSense SNMP module with HOST-RESOURCES + tighter PF MIB walks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,13 +59,17 @@ repos:
         # DL3007 (use specific tag, not :latest) and DL3027 (apt vs
         # apt-get) currently flag the calibre-server Dockerfile; both
         # require Dockerfile rewrites that are out of scope for the CI
-        # cleanup. Tracked for follow-up.
+        # cleanup. DL3002 (last USER not root) is fine for build-time
+        # helper images like snmp-generator-with-mibs that produce a
+        # config artifact at build and never run as a long-lived service.
+        # Tracked for follow-up.
         args:
           - --ignore=DL3008
           - --ignore=DL3009
           - --ignore=DL3015
           - --ignore=DL3007
           - --ignore=DL3027
+          - --ignore=DL3002
 
   # Shell script linting with shellcheck
   # `--severity=error` matches the CI workflow `Lint Validation (shell)` job.

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,20 @@
+# Trivy ignore list for misconfiguration findings on build-time-only
+# helper images. See .github/workflows/security.yml `dependency-scan` job.
+#
+# Format: one rule ID per line; trailing whitespace and `# comment`
+# tails are allowed.
+
+# --- Build-time helper images (no long-lived runtime container) ---
+# dockermaster/docker/snmp-exporter/Dockerfile.generator runs apt-get +
+# download-mibs as root to seed /var/lib/mibs/, then exits. It's used
+# only by ./regen.sh to produce snmp.yml at build time and never serves
+# traffic, so the "USER should not be root" and "no HEALTHCHECK" rules
+# are misapplied to it.
+#
+# These ignores apply repo-wide; the calibre-server Dockerfile flagged
+# by the same rules (alerts #15-22 on the GitHub Security tab) was
+# already accepted as out-of-scope debt in PR #34's hadolint config
+# (.pre-commit-config.yaml: --ignore=DL3002,DL3007,DL3027). Tracked
+# for follow-up cleanup.
+DS-0002    # Image user should not be 'root'
+DS-0026    # No HEALTHCHECK defined

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -90,3 +90,7 @@ ignore: |
   # Frozen as-captured snapshot of the legacy Prometheus deploy on ds-1
   # (see RECON-FINDINGS.md). Kept verbatim for reference, not a config.
   generated/prometheus-thanos-monitoring/legacy-prom-snapshot/
+  # snmp_exporter generator output — formatting matches the upstream
+  # tool's quirks (2-space indent for sub-mappings, etc.) that yamllint's
+  # default profile rejects. Regen via dockermaster/docker/snmp-exporter/regen.sh.
+  dockermaster/docker/snmp-exporter/snmp.yml

--- a/dockermaster/docker/snmp-exporter/Dockerfile.generator
+++ b/dockermaster/docker/snmp-exporter/Dockerfile.generator
@@ -1,0 +1,30 @@
+# Helper Dockerfile to build a snmp-generator image preloaded with the
+# IETF/IANA standard MIBs (via Debian's snmp-mibs-downloader) and our
+# pfSense BEGEMOT MIBs (in mibs/). Used only at regen time; the runtime
+# container is the upstream snmp-exporter image bind-mounting the
+# generated snmp.yml.
+#
+# Build: docker build -f Dockerfile.generator -t local/snmp-generator-with-mibs .
+FROM quay.io/prometheus/snmp-generator:v0.30.1
+
+# hadolint ignore=DL3002
+# Root is required to run apt-get + write to /var/lib/mibs. This image
+# is used only at build/regen time to produce snmp.yml — it's never run
+# as a long-lived service container, so the "last USER should not be
+# root" guidance doesn't apply.
+USER root
+# `snmp-mibs-downloader` is in `non-free` (license-restricted IETF MIB
+# distribution). It installs to /var/lib/mibs/{ietf,iana,site}.
+RUN echo 'deb http://deb.debian.org/debian bookworm main contrib non-free non-free-firmware' \
+      > /etc/apt/sources.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends snmp snmp-mibs-downloader ca-certificates \
+    && download-mibs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Drop the BEGEMOT pfSense MIBs into the site-local search path.
+COPY mibs/*.txt /var/lib/mibs/site/
+
+# Make the comprehensive MIB tree visible to the snmp_exporter generator.
+ENV MIBDIRS=/var/lib/mibs/ietf:/var/lib/mibs/iana:/var/lib/mibs/site:/usr/share/snmp/mibs
+ENV MIBS=ALL

--- a/dockermaster/docker/snmp-exporter/README.md
+++ b/dockermaster/docker/snmp-exporter/README.md
@@ -1,0 +1,115 @@
+# 📊 snmp-exporter — pfSense module regen
+
+The `snmp-exporter` stack scrapes pfSense (and one day, the managed
+switch) via the SNMP v2c protocol. This directory holds the inputs
+needed to **regenerate** the exporter's `snmp.yml` config file from
+scratch, plus the generator output itself.
+
+## What lives here
+
+| File | Purpose |
+| --- | --- |
+| `generator.yml` | Walk list + lookups + auths for the snmp_exporter generator. Source of truth for which OIDs we collect. |
+| `mibs/*.txt` | pfSense-specific BEGEMOT MIB files (pulled from `/usr/share/snmp/mibs/` on pfSense). Non-IETF, not bundled with snmp_exporter. |
+| `Dockerfile.generator` | Builds a generator image preloaded with the IETF/IANA standard MIB tree (via Debian's `snmp-mibs-downloader`) plus the BEGEMOT MIBs. |
+| `regen.sh` | One-shot regen: build the helper image, run the generator, produce `snmp.yml`. |
+| `snmp.yml` | Generator output. Committed to git so we can audit changes. **Community string is the placeholder `public`** — real value is injected at deploy. |
+
+## Module: `pfsense`
+
+Walks what FreeBSD `bsnmpd` (with `mibII`, `pf`, `hostres` modules
+loaded — already enabled on pfSense.home.lcamaral.com) actually exposes:
+
+| MIB / subtree | What we get |
+| --- | --- |
+| **`SNMPv2-MIB`** sys{UpTime,Name,Descr,Contact,Location} | basic identity |
+| **`IF-MIB`** ifTable + ifXTable | per-interface counters (incl. 64-bit HC variants) with `ifName` / `ifAlias` lookups |
+| **`HOST-RESOURCES-MIB`** hrSystem*, hrMemorySize, hrStorage*, hrDevice*, hrProcessorLoad | uptime, RAM, per-mount disk usage, per-CPU load |
+| **`BEGEMOT-PF-MIB`** pfStatus, pfCounter, pfStateTable, pfLimits, pfTimeouts, pfLogInterface, pfInterfaces, pfTablesTbl{Number,Table} | PF firewall daemon health, packet counters, state-table churn, capacity limits, timeouts, per-iface block/pass counters, per-pf-table summaries |
+
+**Deliberately skipped** (would explode scrape size or are noise):
+
+- `pfTablesAddrTable` — per-IP entries inside each PF table (~3000 IPs ×
+  12 columns = 36k metric lines from bogon/abusers/RFC1918 lists)
+- `pfSrcNodes` — per-source-IP, can also explode under load
+- `pfAltq` — Altq queues (deprecated on pfSense, all 0)
+- `pfLabels` — per-PF-rule label counters (niche)
+- `hrSWRun*` — full process table (~128 entries, hex-encoded names from bsnmpd quirk)
+- `UCD-SNMP-MIB` (laTable / systemStats / memory / dskTable) — not in
+  `bsnmpd`, only in `net-snmp`
+
+Result: ~145 walks producing ~7,700 metric lines per scrape (was a
+17,500-line snmp.yml producing ~850 metric lines plus 36k+ of
+pfTablesAddr noise on a full walk).
+
+## Regenerating
+
+```bash
+cd dockermaster/docker/snmp-exporter
+./regen.sh
+```
+
+The script builds `local/snmp-generator-with-mibs` (helper image bundling
+the IETF MIB tree from Debian's `snmp-mibs-downloader` + the BEGEMOT MIBs
+from `mibs/`), then runs `snmp_exporter generator generate` against
+`generator.yml` and writes `snmp.yml`.
+
+If you change the walk list, edit `generator.yml` and re-run `regen.sh`.
+
+## Deploying (current state)
+
+> ⚠️ This is the IaC-anti-pattern part. The runtime `snmp.yml` is
+> bind-mounted from `/nfs/dockermaster/docker/snmp-exporter/snmp.yml`
+> (see `terraform/portainer/stacks/snmp-exporter.yml` line 37). Until we
+> migrate to a baked-image deploy (see _Phase E_ below), the deploy is a
+> manual scp + container restart.
+
+```bash
+# 1. Pull the live community string from Vault (NOT committed to git).
+COMMUNITY=$(vault kv get -field=community secret/homelab/pfsense/snmp)
+
+# 2. Render snmp.yml with the real community substituted in.
+sed "s/community: public/community: $COMMUNITY/" snmp.yml > /tmp/snmp.yml.deploy
+
+# 3. Drop on dockermaster's NFS share, restart exporter.
+scp /tmp/snmp.yml.deploy 192.168.48.45:/nfs/dockermaster/docker/snmp-exporter/snmp.yml
+ssh 192.168.48.45 'docker restart snmp-exporter-snmp-exporter-1'
+
+# 4. Verify Prometheus snmp-pfsense target stays UP and new metrics flow.
+ssh 192.168.48.45 'docker exec prometheus-prometheus-1-1 wget -qO- "http://localhost:9090/api/v1/query?query=pfStateTableCount" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d[\"data\"][\"result\"][0])"'
+
+# 5. Clean up.
+rm /tmp/snmp.yml.deploy
+```
+
+## Phase E: bake into a custom image (the IaC-correct fix)
+
+The bind-mount above is tracked as an IaC-first violation
+(memory: `feedback_iac_first_principle.md`). Migration plan:
+
+1. Build a Dockerfile in this directory that `FROM`s the upstream
+   snmp-exporter image and `COPY`s `snmp.yml` to `/etc/snmp_exporter/snmp.yml`.
+2. Wire the build into the existing `build-multi-type-images.yml` GitHub
+   workflow → push to `registry.cf.lcamaral.com/snmp-exporter:<tag>`.
+3. Inject the community at runtime via env var instead of file
+   substitution (`SNMP_AUTH_PFSENSE_V2_COMMUNITY` → injected via
+   compose `env_file:` from a Vault-rendered `.env`).
+4. Update `terraform/portainer/stacks/snmp-exporter.yml` to use the
+   custom image, drop the bind-mount.
+5. `terraform apply`; trigger Portainer stack stop+start (per
+   `feedback_portainer_stack_redeploy.md`).
+
+Out of scope for the initial regen PR; tracked as a follow-up.
+
+## Troubleshooting
+
+- _"cannot find oid 'X' to walk"_ — generator can't find the OID in its
+  loaded MIBs. Either provide the missing MIB file in `mibs/` or use a
+  numeric OID instead of a name in `generator.yml`'s `walk:` list.
+- _"Missing MIB"_ during build — a referenced IMPORTS module isn't in
+  `/var/lib/mibs/{ietf,iana,site}/`. Add the MIB file to `mibs/` and
+  rebuild.
+- _Empty scrape response_ — pfSense's bsnmpd doesn't load that module by
+  default. Check `/var/etc/snmpd.conf` on pfSense for
+  `begemotSnmpdModulePath."<name>"` entries; add the missing one via
+  Services → SNMP → Modules in the pfSense UI.

--- a/dockermaster/docker/snmp-exporter/generator.yml
+++ b/dockermaster/docker/snmp-exporter/generator.yml
@@ -1,0 +1,162 @@
+# snmp_exporter generator config — regenerate the bind-mounted snmp.yml
+# at /nfs/dockermaster/docker/snmp-exporter/snmp.yml.
+#
+# Generated output: ./snmp.yml (run from this directory)
+# Regen command:
+#   cd dockermaster/docker/snmp-exporter
+#   docker run --rm -v "$PWD:/opt" --network host \
+#     quay.io/prometheus/snmp-generator:v0.30.1 generate \
+#     -g generator.yml -o snmp.yml
+#
+# Then deploy:
+#   scp snmp.yml dockermaster:/nfs/dockermaster/docker/snmp-exporter/snmp.yml
+#   ssh 192.168.48.45 'docker restart snmp-exporter-snmp-exporter-1'
+#
+# Auth values are placeholders — the live community string is replaced
+# from Vault by the snmp-exporter stack at deploy time, NOT in this
+# checked-in file. Keep this committed; the generator only uses `auths:`
+# for documentation and to know SNMP version. The runtime community
+# string is selected by the Prometheus scrape job's `auth:` param
+# matching one of the keys here, then resolved by snmp-exporter from
+# the auth block. (See snmp-exporter.yml stack file for the bind-mount
+# pattern.)
+
+auths:
+  pfsense_v2:
+    version: 2
+    community: public  # placeholder; live value injected at deploy time
+
+modules:
+  pfsense:
+    # Walk only what pfSense's bsnmpd actually exposes:
+    # - mibII   → SNMPv2-MIB (sysUpTime, sysName, sysDescr) + IF-MIB
+    # - pf      → BEGEMOT-PF-MIB (pfStateTable*, pfStatus*, pfInterfacesIf*)
+    # - hostres → HOST-RESOURCES-MIB (hrSystem*, hrStorage*, hrProcessorLoad)
+    #
+    # Modules NOT enabled on pfSense bsnmpd (would time out):
+    # - UCD-SNMP-MIB (laTable / systemStats / memory / dskTable) — not in bsnmpd
+    # - net-snmp specific modules — bsnmpd, not net-snmp
+    walk:
+      # SNMP v2 MIB basics
+      - sysUpTime
+      - sysName
+      - sysDescr
+      - sysContact
+      - sysLocation
+
+      # IF-MIB — interface counters (use HC variants for 64-bit counters)
+      - ifNumber
+      - ifIndex
+      - ifDescr
+      - ifType
+      - ifMtu
+      - ifSpeed
+      - ifPhysAddress
+      - ifAdminStatus
+      - ifOperStatus
+      - ifLastChange
+      - ifInDiscards
+      - ifInErrors
+      - ifInUnknownProtos
+      - ifOutDiscards
+      - ifOutErrors
+      - ifName
+      - ifInMulticastPkts
+      - ifInBroadcastPkts
+      - ifOutMulticastPkts
+      - ifOutBroadcastPkts
+      - ifHCInOctets
+      - ifHCInUcastPkts
+      - ifHCInMulticastPkts
+      - ifHCInBroadcastPkts
+      - ifHCOutOctets
+      - ifHCOutUcastPkts
+      - ifHCOutMulticastPkts
+      - ifHCOutBroadcastPkts
+      - ifHighSpeed
+      - ifAlias
+
+      # BEGEMOT-PF-MIB — pfSense-specific firewall metrics. Walk specific
+      # subtrees, NOT the whole pfMib (1.3.6.1.4.1.12325.1.200) — that
+      # would pull in `pfTablesAddrTable` which has ~3000 per-IP entries
+      # × 12 columns = 36k metric lines per scrape (mostly noise from
+      # bogon/abusers/RFC1918 lists). Same with pfLabels (per-PF-rule
+      # label counters, niche), pfAltq (Altq is deprecated on pfSense),
+      # and pfSrcNodes (per-source-IP, can also explode).
+      #
+      # The MIB tree under begemotPfObjects (1.3.6.1.4.1.12325.1.200.1):
+      #   .1 pfStatus       — daemon Running/Runtime/Debug/HostId
+      #   .2 pfCounter      — global Match/BadOffset/Fragment/Short/Normalize/MemDrop counters
+      #   .3 pfStateTable   — pfStateTableCount + insert/remove/search counters
+      #   .4 pfSrcNodes     — per-source-IP (skip — can explode)
+      #   .5 pfLimits       — pfLimitsStates/SrcNodes/Frags (capacity planning)
+      #   .6 pfTimeouts     — TCP/UDP/ICMP timeout settings (config snapshot)
+      #   .7 pfLogInterface — log iface stats
+      #   .8 pfInterfaces   — pfInterfacesIfNumber + pfInterfacesIfTable (per-iface block/pass byte/pkt counters)
+      #   .9 pfTables       — only walk .1 (tbl count) and .2 (tbl summary), NOT .3 (per-addr)
+      #   .10 pfAltq         — Altq queues (deprecated on pfSense, all 0)
+      #   .11 pfLabels       — per-PF-rule label counters (niche)
+      - 1.3.6.1.4.1.12325.1.200.1.1    # pfStatus
+      - 1.3.6.1.4.1.12325.1.200.1.2    # pfCounter
+      - 1.3.6.1.4.1.12325.1.200.1.3    # pfStateTable
+      - 1.3.6.1.4.1.12325.1.200.1.5    # pfLimits
+      - 1.3.6.1.4.1.12325.1.200.1.6    # pfTimeouts
+      - 1.3.6.1.4.1.12325.1.200.1.7    # pfLogInterface
+      - 1.3.6.1.4.1.12325.1.200.1.8    # pfInterfaces
+      - 1.3.6.1.4.1.12325.1.200.1.9.1  # pfTablesTblNumber
+      - 1.3.6.1.4.1.12325.1.200.1.9.2  # pfTablesTblTable (per-table summary)
+
+      # HOST-RESOURCES-MIB — system-level metrics from hostres module
+      - hrSystemUptime
+      - hrSystemDate
+      - hrSystemNumUsers
+      - hrSystemProcesses
+      - hrSystemMaxProcesses
+      - hrMemorySize
+      - hrStorageType
+      - hrStorageDescr
+      - hrStorageAllocationUnits
+      - hrStorageSize
+      - hrStorageUsed
+      - hrStorageAllocationFailures
+      - hrDeviceType
+      - hrDeviceDescr
+      - hrDeviceStatus
+      - hrDeviceErrors
+      - hrProcessorLoad
+      # hrSWRun*  — skipped: returns the full process table (~128
+      #             entries with hex-encoded names from bsnmpd's
+      #             FreeBSD-quirky output); not useful as long-term
+      #             time-series, drop to keep scrape size manageable.
+
+    lookups:
+      # Annotate interface metrics with ifName and ifAlias so dashboards
+      # don't have to join via ifIndex.
+      - source_indexes: [ifIndex]
+        lookup: ifAlias
+      - source_indexes: [ifIndex]
+        lookup: ifDescr
+      - source_indexes: [ifIndex]
+        lookup: ifName
+      # Annotate hrStorage metrics with the mount-point description.
+      - source_indexes: [hrStorageIndex]
+        lookup: hrStorageDescr
+      # Annotate hrProcessor metrics with the device descr (CPU model).
+      - source_indexes: [hrDeviceIndex]
+        lookup: hrDeviceDescr
+
+    overrides:
+      # ifAlias → string (DisplayString) keeps the textual interface
+      # description on metrics rather than dropping it.
+      ifAlias:
+        type: DisplayString
+      ifName:
+        type: DisplayString
+      hrStorageDescr:
+        type: DisplayString
+      hrDeviceDescr:
+        type: DisplayString
+      sysName:
+        type: DisplayString
+      sysDescr:
+        type: DisplayString

--- a/dockermaster/docker/snmp-exporter/mibs/BEGEMOT-MIB.txt
+++ b/dockermaster/docker/snmp-exporter/mibs/BEGEMOT-MIB.txt
@@ -1,0 +1,62 @@
+--
+-- Copyright (c) 2001-2003
+--	Fraunhofer Institute for Open Communication Systems (FhG Fokus).
+--	All rights reserved.
+--
+-- Author: Harti Brandt <harti@freebsd.org>
+--
+-- Redistribution and use in source and binary forms, with or without
+-- modification, are permitted provided that the following conditions
+-- are met:
+-- 1. Redistributions of source code must retain the above copyright
+--    notice, this list of conditions and the following disclaimer.
+-- 2. Redistributions in binary form must reproduce the above copyright
+--    notice, this list of conditions and the following disclaimer in the
+--    documentation and/or other materials provided with the distribution.
+--
+-- THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+-- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+-- ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE LIABLE
+-- FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-- DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+-- OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+-- HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+-- LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+-- OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+-- SUCH DAMAGE.
+--
+-- $Begemot: bsnmp/snmpd/BEGEMOT-MIB.txt,v 1.5 2004/08/06 08:47:07 brandt Exp $
+--
+-- Begemot private definitions and root.
+--
+BEGEMOT-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY
+	FROM SNMPv2-SMI
+    fokus
+	FROM FOKUS-MIB;
+
+begemot MODULE-IDENTITY
+    LAST-UPDATED "200201300000Z"
+    ORGANIZATION "Fraunhofer FOKUS, CATS"
+    CONTACT-INFO
+	    "		Hartmut Brandt
+
+	     Postal:	Fraunhofer Institute for Open Communication Systems
+			Kaiserin-Augusta-Allee 31
+			10589 Berlin
+			Germany
+
+	     Fax:	+49 30 3463 7352
+
+	     E-mail:	harti@freebsd.org"
+    DESCRIPTION
+	    "The root of the Begemot subtree of the fokus tree."
+    REVISION "200201300000Z"
+    DESCRIPTION
+	    "Initial revision."
+    ::= { fokus 1 }
+
+END

--- a/dockermaster/docker/snmp-exporter/mibs/BEGEMOT-PF-MIB.txt
+++ b/dockermaster/docker/snmp-exporter/mibs/BEGEMOT-PF-MIB.txt
@@ -1,0 +1,1343 @@
+--
+-- ----------------------------------------------------------------------------
+-- "THE BEER-WARE LICENSE" (Revision 42):
+-- <philip@FreeBSD.org> wrote this file.  As long as you retain this notice you
+-- can do whatever you want with this stuff. If we meet some day, and you think
+-- this stuff is worth it, you can buy me a beer in return.   -Philip Paeps
+-- ----------------------------------------------------------------------------
+--
+
+BEGEMOT-PF-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, Counter64, Integer32,
+    TimeTicks, Unsigned32
+	FROM SNMPv2-SMI
+    TruthValue
+	FROM SNMPv2-TC
+    InetAddress, InetAddressType, InetAddressPrefixLength
+	FROM INET-ADDRESS-MIB
+    begemot
+	FROM BEGEMOT-MIB;
+
+begemotPf MODULE-IDENTITY
+    LAST-UPDATED "202503190000Z"
+    ORGANIZATION "Alternative Enterprises (HK) Limited"
+    CONTACT-INFO
+	    "		Philip Paeps
+
+	     E-Mail:	philip@FreeBSD.org"
+    DESCRIPTION
+	    "The Begemot MIB for the pf packet filter."
+    REVISION	"202503190000Z"
+    DESCRIPTION
+		"Reverted pfInterfacesIfRefsState to Unsigned32"
+    REVISION	"201003180000Z"
+    DESCRIPTION
+		"Modified pfTablesAddrEntry to support IPv6
+		addresses - added pfTablesAddrNetType column
+		and modified type of pfTablesAddrNet to
+		InetAddress."
+    REVISION	"200912050000Z"
+    DESCRIPTION
+	    "Added support for retrieving counters of labeled
+	    pf filter rules via pfLabelspfLabels subtree."
+    REVISION	"200501240000Z"
+    DESCRIPTION
+	    "Initial revision."
+
+    ::= { begemot 200 }
+
+begemotPfObjects	OBJECT IDENTIFIER ::= { begemotPf 1 }
+
+-- --------------------------------------------------------------------------
+
+pfStatus		OBJECT IDENTIFIER ::= { begemotPfObjects 1 }
+pfCounter		OBJECT IDENTIFIER ::= { begemotPfObjects 2 }
+pfStateTable		OBJECT IDENTIFIER ::= { begemotPfObjects 3 }
+pfSrcNodes		OBJECT IDENTIFIER ::= { begemotPfObjects 4 }
+pfLimits		OBJECT IDENTIFIER ::= { begemotPfObjects 5 }
+pfTimeouts		OBJECT IDENTIFIER ::= { begemotPfObjects 6 }
+pfLogInterface		OBJECT IDENTIFIER ::= { begemotPfObjects 7 }
+pfInterfaces		OBJECT IDENTIFIER ::= { begemotPfObjects 8 }
+pfTables		OBJECT IDENTIFIER ::= { begemotPfObjects 9 }
+pfAltq			OBJECT IDENTIFIER ::= { begemotPfObjects 10 }
+pfLabels		OBJECT IDENTIFIER ::= { begemotPfObjects 11 }
+
+-- --------------------------------------------------------------------------
+
+--
+-- status information
+--
+
+pfStatusRunning OBJECT-TYPE
+    SYNTAX	TruthValue
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"True if pf is currently enabled."
+    ::= { pfStatus 1 }
+
+pfStatusRuntime OBJECT-TYPE
+    SYNTAX	TimeTicks
+    UNITS	"1/100th of a Second"
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Indicates how long pf has been enabled.  If pf is not currently
+	enabled, indicates how long it has been disabled.  If pf has not
+	been enabled or disabled since the system was started, the value
+	will be 0."
+    ::= { pfStatus 2 }
+
+pfStatusDebug OBJECT-TYPE
+    SYNTAX	INTEGER { none(0), urgent(1), misc(2), loud(3) }
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Indicates the debug level at which pf is running."
+    ::= { pfStatus 3 }
+
+pfStatusHostId OBJECT-TYPE
+    SYNTAX	OCTET STRING
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The (unique) host identifier of the machine running pf."
+    ::= { pfStatus 4 }
+
+-- --------------------------------------------------------------------------
+
+--
+-- counters
+--
+
+pfCounterMatch OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Number of packets that matched a filter rule."
+    ::= { pfCounter 1 }
+
+pfCounterBadOffset OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Number of packets with bad offset."
+    ::= { pfCounter 2 }
+
+pfCounterFragment OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Number of fragmented packets."
+    ::= { pfCounter 3 }
+
+pfCounterShort OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Number of short packets."
+    ::= { pfCounter 4 }
+
+pfCounterNormalize OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Number of normalized packets."
+    ::= { pfCounter 5 }
+
+pfCounterMemDrop OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Number of packets dropped due to memory limitations."
+    ::= { pfCounter 6 }
+
+-- --------------------------------------------------------------------------
+
+--
+-- state table
+--
+
+pfStateTableCount OBJECT-TYPE
+    SYNTAX	Unsigned32
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Number of entries in the state table."
+    ::= { pfStateTable 1 }
+
+pfStateTableSearches OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Number of searches against the state table."
+    ::= { pfStateTable 2 }
+
+pfStateTableInserts OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Number of entries inserted into the state table."
+    ::= { pfStateTable 3 }
+
+pfStateTableRemovals OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Number of entries removed from the state table."
+    ::= { pfStateTable 4 }
+
+-- --------------------------------------------------------------------------
+
+--
+-- source nodes
+--
+
+pfSrcNodesCount OBJECT-TYPE
+    SYNTAX	Unsigned32
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Number of entries in the source tracking table."
+    ::= { pfSrcNodes 1 }
+
+pfSrcNodesSearches OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Number of searches against the source tracking table."
+    ::= { pfSrcNodes 2 }
+
+pfSrcNodesInserts OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Number of entries inserted into the source tracking table."
+    ::= { pfSrcNodes 3 }
+
+pfSrcNodesRemovals OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Number of entries removed from the source tracking table."
+    ::= { pfSrcNodes 4 }
+
+-- --------------------------------------------------------------------------
+
+--
+-- limits
+--
+
+pfLimitsStates OBJECT-TYPE
+    SYNTAX	Unsigned32
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Maximum number of 'keep state' rules in the ruleset."
+    ::= { pfLimits 1 }
+
+pfLimitsSrcNodes OBJECT-TYPE
+    SYNTAX	Unsigned32
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Maximum number of 'sticky-address' or 'source-track' rules
+	in the ruleset."
+    ::= { pfLimits 2 }
+
+pfLimitsFrags OBJECT-TYPE
+    SYNTAX	Unsigned32
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Maximum number of 'scrub' rules in the ruleset."
+    ::= { pfLimits 3 }
+
+-- --------------------------------------------------------------------------
+
+--
+-- timeouts
+--
+
+pfTimeoutsTcpFirst OBJECT-TYPE
+    SYNTAX	Integer32
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"State after the first packet in a connection."
+    ::= { pfTimeouts 1 }
+
+pfTimeoutsTcpOpening OBJECT-TYPE
+    SYNTAX	Integer32
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"State before the destination host ever sends a packet."
+    ::= { pfTimeouts 2 }
+
+pfTimeoutsTcpEstablished OBJECT-TYPE
+    SYNTAX	Integer32
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The fully established state."
+    ::= { pfTimeouts 3 }
+
+pfTimeoutsTcpClosing OBJECT-TYPE
+    SYNTAX	Integer32
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"State after the first FIN has been sent."
+    ::= { pfTimeouts 4 }
+
+pfTimeoutsTcpFinWait OBJECT-TYPE
+    SYNTAX	Integer32
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"State after both FINs have been exchanged and the
+	connection is closed."
+    ::= { pfTimeouts 5 }
+
+pfTimeoutsTcpClosed OBJECT-TYPE
+    SYNTAX	Integer32
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"State after one endpoint sends an RST."
+    ::= { pfTimeouts 6 }
+
+pfTimeoutsUdpFirst OBJECT-TYPE
+    SYNTAX	Integer32
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"State after the first packet."
+    ::= { pfTimeouts 7 }
+
+pfTimeoutsUdpSingle OBJECT-TYPE
+    SYNTAX	Integer32
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"State if the source host sends more than one packet but
+	the destination host has never sent one back."
+    ::= { pfTimeouts 8 }
+
+pfTimeoutsUdpMultiple OBJECT-TYPE
+    SYNTAX	Integer32
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"State if both hosts have sent packets."
+    ::= { pfTimeouts 9 }
+
+pfTimeoutsIcmpFirst OBJECT-TYPE
+    SYNTAX	Integer32
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"State after the first packet."
+    ::= { pfTimeouts 10 }
+
+pfTimeoutsIcmpError OBJECT-TYPE
+    SYNTAX	Integer32
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"State after an ICMP error came back in response to an
+	ICMP packet."
+    ::= { pfTimeouts 11 }
+
+pfTimeoutsOtherFirst OBJECT-TYPE
+    SYNTAX	Integer32
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"State after the first packet."
+    ::= { pfTimeouts 12 }
+
+pfTimeoutsOtherSingle OBJECT-TYPE
+    SYNTAX	Integer32
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"State if the source host sends more than one packet but
+	the destination host has never sent one back."
+    ::= { pfTimeouts 13 }
+
+pfTimeoutsOtherMultiple OBJECT-TYPE
+    SYNTAX	Integer32
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"State if both hosts have sent packets."
+    ::= { pfTimeouts 14 }
+
+pfTimeoutsFragment OBJECT-TYPE
+    SYNTAX	Integer32
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Seconds before an unassembled fragment is expired."
+    ::= { pfTimeouts 15 }
+
+pfTimeoutsInterval OBJECT-TYPE
+    SYNTAX	Integer32
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Interval between purging expired states and fragments."
+    ::= { pfTimeouts 16 }
+
+pfTimeoutsAdaptiveStart OBJECT-TYPE
+    SYNTAX	Integer32
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"When the number of state entries exceeds this value,
+	adaptive scaling begins."
+    ::= { pfTimeouts 17 }
+
+pfTimeoutsAdaptiveEnd OBJECT-TYPE
+    SYNTAX	Integer32
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"When reaching this number of state entries, all timeout
+	values become zero, effectively purging all state entries
+	immediately."
+    ::= { pfTimeouts 18 }
+
+pfTimeoutsSrcNode OBJECT-TYPE
+    SYNTAX	Integer32
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Length of time to retain a source tracking entry after
+	the last state expires."
+    ::= { pfTimeouts 19 }
+
+-- --------------------------------------------------------------------------
+
+--
+-- log interface
+--
+
+pfLogInterfaceName OBJECT-TYPE
+    SYNTAX	OCTET STRING
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The name of the interface configured with 'set loginterface'.
+	If no interface has been configured, the object will be empty."
+    ::= { pfLogInterface 1 }
+
+pfLogInterfaceIp4BytesIn OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Number of IPv4 bytes passed in on the loginterface."
+    ::= { pfLogInterface 2 }
+
+pfLogInterfaceIp4BytesOut OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Number of IPv4 bytes passed out on the loginterface."
+    ::= { pfLogInterface 3 }
+
+pfLogInterfaceIp4PktsInPass OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Number of IPv4 packets passed in on the loginterface."
+    ::= { pfLogInterface 4 }
+
+pfLogInterfaceIp4PktsInDrop OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Number of IPv4 packets dropped coming in on the loginterface."
+    ::= { pfLogInterface 5 }
+
+pfLogInterfaceIp4PktsOutPass OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Number of IPv4 packets passed out on the loginterface."
+    ::= { pfLogInterface 6 }
+
+pfLogInterfaceIp4PktsOutDrop OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Number of IPv4 packets dropped going out on the loginterface."
+    ::= { pfLogInterface 7 }
+
+pfLogInterfaceIp6BytesIn OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Number of IPv6 bytes passed in on the loginterface."
+    ::= { pfLogInterface 8 }
+
+pfLogInterfaceIp6BytesOut OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Number of IPv6 bytes passed out on the loginterface."
+    ::= { pfLogInterface 9 }
+
+pfLogInterfaceIp6PktsInPass OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Number of IPv6 packets passed in on the loginterface."
+    ::= { pfLogInterface 10 }
+
+pfLogInterfaceIp6PktsInDrop OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Number of IPv6 packets dropped coming in on the loginterface."
+    ::= { pfLogInterface 11 }
+
+pfLogInterfaceIp6PktsOutPass OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Number of IPv6 packets passed out on the loginterface."
+    ::= { pfLogInterface 12 }
+
+pfLogInterfaceIp6PktsOutDrop OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Number of IPv6 packets dropped going out on the loginterface."
+    ::= { pfLogInterface 13 }
+
+-- --------------------------------------------------------------------------
+
+--
+-- interfaces
+--
+
+pfInterfacesIfNumber OBJECT-TYPE
+    SYNTAX	Integer32
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The number of network interfaces on this system."
+    ::= { pfInterfaces 1 }
+
+pfInterfacesIfTable OBJECT-TYPE
+    SYNTAX	SEQUENCE OF PfInterfacesIfEntry
+    MAX-ACCESS	not-accessible
+    STATUS	current
+    DESCRIPTION
+	"Table of network interfaces, indexed on pfInterfacesIfNumber."
+    ::= { pfInterfaces 2 }
+
+pfInterfacesIfEntry OBJECT-TYPE
+    SYNTAX	PfInterfacesIfEntry
+    MAX-ACCESS	not-accessible
+    STATUS	current
+    DESCRIPTION
+	"An entry in the pfInterfacesIfTable containing information
+	about a particular network interface in the machine."
+    INDEX	{ pfInterfacesIfIndex }
+    ::= { pfInterfacesIfTable 1 }
+
+PfInterfacesIfEntry ::= SEQUENCE {
+    pfInterfacesIfIndex		    Integer32,
+    pfInterfacesIfDescr		    OCTET STRING,
+    pfInterfacesIfType		    INTEGER,
+    pfInterfacesIfTZero		    TimeTicks,
+    pfInterfacesIfRefsState	    Unsigned32,
+    pfInterfacesIfRefsRule	    Unsigned32,
+    pfInterfacesIf4BytesInPass	    Counter64,
+    pfInterfacesIf4BytesInBlock	    Counter64,
+    pfInterfacesIf4BytesOutPass	    Counter64,
+    pfInterfacesIf4BytesOutBlock    Counter64,
+    pfInterfacesIf4PktsInPass	    Counter64,
+    pfInterfacesIf4PktsInBlock	    Counter64,
+    pfInterfacesIf4PktsOutPass	    Counter64,
+    pfInterfacesIf4PktsOutBlock	    Counter64,
+    pfInterfacesIf6BytesInPass	    Counter64,
+    pfInterfacesIf6BytesInBlock	    Counter64,
+    pfInterfacesIf6BytesOutPass	    Counter64,
+    pfInterfacesIf6BytesOutBlock    Counter64,
+    pfInterfacesIf6PktsInPass	    Counter64,
+    pfInterfacesIf6PktsInBlock	    Counter64,
+    pfInterfacesIf6PktsOutPass	    Counter64,
+    pfInterfacesIf6PktsOutBlock	    Counter64
+}
+
+pfInterfacesIfIndex OBJECT-TYPE
+    SYNTAX	Integer32 (1..2147483647)
+    MAX-ACCESS	not-accessible
+    STATUS	current
+    DESCRIPTION
+	"A unique value, greater than zero, for each interface."
+    ::= { pfInterfacesIfEntry 1 }
+
+pfInterfacesIfDescr OBJECT-TYPE
+    SYNTAX	OCTET STRING
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The name of the interface."
+    ::= { pfInterfacesIfEntry 2 }
+
+pfInterfacesIfType OBJECT-TYPE
+    SYNTAX	INTEGER { group(0), instance(1), detached(2) }
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Indicates whether the interface is a group inteface, an
+	interface instance, or whether it has been removed or
+	destroyed."
+    ::= { pfInterfacesIfEntry 3 }
+
+pfInterfacesIfTZero OBJECT-TYPE
+    SYNTAX	TimeTicks
+    UNITS	"1/100th of a Second"
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Time since statistics were last reset or since the
+	interface was loaded."
+    ::= { pfInterfacesIfEntry 4 }
+
+pfInterfacesIfRefsState OBJECT-TYPE
+    SYNTAX	Unsigned32
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The number of state and/or source track entries referencing
+	this interface."
+    ::= { pfInterfacesIfEntry 5 }
+
+pfInterfacesIfRefsRule OBJECT-TYPE
+    SYNTAX	Unsigned32
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The number of rules referencing this interface."
+    ::= { pfInterfacesIfEntry 6 }
+
+pfInterfacesIf4BytesInPass OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The number of IPv4 bytes passed coming in on this interface."
+    ::= { pfInterfacesIfEntry 7 }
+
+pfInterfacesIf4BytesInBlock OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The number of IPv4 bytes blocked coming in on this interface."
+    ::= { pfInterfacesIfEntry 8 }
+
+pfInterfacesIf4BytesOutPass OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The number of IPv4 bytes passed going out on this interface."
+    ::= { pfInterfacesIfEntry 9 }
+
+pfInterfacesIf4BytesOutBlock OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The number of IPv4 bytes blocked going out on this interface."
+    ::= { pfInterfacesIfEntry 10 }
+
+pfInterfacesIf4PktsInPass OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The number of IPv4 packets passed coming in on this interface."
+    ::= { pfInterfacesIfEntry 11 }
+
+pfInterfacesIf4PktsInBlock OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The number of IPv4 packets blocked coming in on this interface."
+    ::= { pfInterfacesIfEntry 12 }
+
+pfInterfacesIf4PktsOutPass OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The number of IPv4 packets passed going out on this interface."
+    ::= { pfInterfacesIfEntry 13 }
+
+pfInterfacesIf4PktsOutBlock OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The number of IPv4 packets blocked going out on this interface."
+    ::= { pfInterfacesIfEntry 14 }
+
+pfInterfacesIf6BytesInPass OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The number of IPv6 bytes passed coming in on this interface."
+    ::= { pfInterfacesIfEntry 15 }
+
+pfInterfacesIf6BytesInBlock OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The number of IPv6 bytes blocked coming in on this interface."
+    ::= { pfInterfacesIfEntry 16 }
+
+pfInterfacesIf6BytesOutPass OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The number of IPv6 bytes passed going out on this interface."
+    ::= { pfInterfacesIfEntry 17 }
+
+pfInterfacesIf6BytesOutBlock OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The number of IPv6 bytes blocked going out on this interface."
+    ::= { pfInterfacesIfEntry 18 }
+
+
+pfInterfacesIf6PktsInPass OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The number of IPv6 packets passed coming in on this interface."
+    ::= { pfInterfacesIfEntry 19 }
+
+pfInterfacesIf6PktsInBlock OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The number of IPv6 packets blocked coming in on this interface."
+    ::= { pfInterfacesIfEntry 20 }
+
+pfInterfacesIf6PktsOutPass OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The number of IPv6 packets passed going out on this interface."
+    ::= { pfInterfacesIfEntry 21 }
+
+pfInterfacesIf6PktsOutBlock OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The number of IPv6 packets blocked going out on this interface."
+    ::= { pfInterfacesIfEntry 22 }
+
+-- --------------------------------------------------------------------------
+
+--
+-- tables
+--
+
+pfTablesTblNumber OBJECT-TYPE
+    SYNTAX	Integer32
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The number of tables on this system."
+    ::= { pfTables 1 }
+
+pfTablesTblTable OBJECT-TYPE
+    SYNTAX	SEQUENCE OF PfTablesTblEntry
+    MAX-ACCESS	not-accessible
+    STATUS	current
+    DESCRIPTION
+	"Table of tables, index on pfTablesTblIndex."
+    ::= { pfTables 2 }
+
+pfTablesTblEntry OBJECT-TYPE
+    SYNTAX	PfTablesTblEntry
+    MAX-ACCESS	not-accessible
+    STATUS	current
+    DESCRIPTION
+	"Any entry in the pfTablesTblTable containing information
+	about a particular table on the system."
+    INDEX	{ pfTablesTblIndex }
+    ::= { pfTablesTblTable 1 }
+
+PfTablesTblEntry ::= SEQUENCE {
+    pfTablesTblIndex		    Integer32,
+    pfTablesTblDescr		    OCTET STRING,
+    pfTablesTblCount		    Integer32,
+    pfTablesTblTZero		    TimeTicks,
+    pfTablesTblRefsAnchor	    Integer32,
+    pfTablesTblRefsRule		    Integer32,
+    pfTablesTblEvalMatch	    Counter64,
+    pfTablesTblEvalNoMatch	    Counter64,
+    pfTablesTblBytesInPass	    Counter64,
+    pfTablesTblBytesInBlock	    Counter64,
+    pfTablesTblBytesInXPass	    Counter64,
+    pfTablesTblBytesOutPass	    Counter64,
+    pfTablesTblBytesOutBlock	    Counter64,
+    pfTablesTblBytesOutXPass	    Counter64,
+    pfTablesTblPktsInPass	    Counter64,
+    pfTablesTblPktsInBlock	    Counter64,
+    pfTablesTblPktsInXPass	    Counter64,
+    pfTablesTblPktsOutPass	    Counter64,
+    pfTablesTblPktsOutBlock	    Counter64,
+    pfTablesTblPktsOutXPass	    Counter64
+}
+
+pfTablesTblIndex OBJECT-TYPE
+    SYNTAX	Integer32 (1..2147483647)
+    MAX-ACCESS  not-accessible
+    STATUS	current
+    DESCRIPTION
+        "A unique value, greater than zero, for each table."
+    ::= { pfTablesTblEntry 1 }
+
+pfTablesTblDescr OBJECT-TYPE
+    SYNTAX	OCTET STRING
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+        "The name of the table."
+    ::= { pfTablesTblEntry 2 }
+
+pfTablesTblCount OBJECT-TYPE
+    SYNTAX	Integer32
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+        "The number of addresses in the table."
+    ::= { pfTablesTblEntry 3 }
+
+pfTablesTblTZero OBJECT-TYPE
+    SYNTAX	TimeTicks
+    UNITS	"1/100th of a Second"
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+        "The time passed since the statistics of this table were last
+        cleared or the time since this table was loaded, whichever is
+        sooner."
+    ::= { pfTablesTblEntry 4 }
+
+pfTablesTblRefsAnchor OBJECT-TYPE
+    SYNTAX	Integer32
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+        "The number of anchors referencing this table."
+    ::= { pfTablesTblEntry 5 }
+
+pfTablesTblRefsRule OBJECT-TYPE
+    SYNTAX	Integer32
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+        "The number of rules referencing this table."
+    ::= { pfTablesTblEntry 6 }
+
+pfTablesTblEvalMatch OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+        "The number of evaluations returning a match."
+    ::= { pfTablesTblEntry 7 }
+
+pfTablesTblEvalNoMatch OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+        "The number of evaluations not returning a match."
+    ::= { pfTablesTblEntry 8 }
+
+pfTablesTblBytesInPass OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+        "The number of bytes passed in matching the table."
+    ::= { pfTablesTblEntry 9 }
+
+pfTablesTblBytesInBlock	OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+        "The number of bytes blocked coming in matching the table."
+    ::= { pfTablesTblEntry 10 }
+
+pfTablesTblBytesInXPass OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+        "The number of bytes statefully passed in where the state
+        entry refers to the table, but the table no longer contains
+	the address in question."
+    ::= { pfTablesTblEntry 11 }
+
+pfTablesTblBytesOutPass	OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+        "The number of bytes passed out matching the table."
+    ::= { pfTablesTblEntry 12 }
+
+pfTablesTblBytesOutBlock OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+        "The number of bytes blocked going out matching the table."
+    ::= { pfTablesTblEntry 13 }
+
+pfTablesTblBytesOutXPass OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+        "The number of bytes statefully passed out where the state
+        entry refers to the table, but the table no longer contains
+	the address in question."
+    ::= { pfTablesTblEntry 14 }
+
+pfTablesTblPktsInPass OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+        "The number of packets passed in matching the table."
+    ::= { pfTablesTblEntry 15 }
+
+pfTablesTblPktsInBlock OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+        "The number of packets blocked coming in matching the table."
+    ::= { pfTablesTblEntry 16 }
+
+pfTablesTblPktsInXPass OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+        "The number of packets statefully passed in where the state
+        entry refers to the table, but the table no longer contains
+	the address in question."
+    ::= { pfTablesTblEntry 17 }
+
+pfTablesTblPktsOutPass OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+        "The number of packets passed out matching the table."
+    ::= { pfTablesTblEntry 18 }
+
+pfTablesTblPktsOutBlock OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+        "The number of packets blocked going out matching the table."
+    ::= { pfTablesTblEntry 19 }
+
+pfTablesTblPktsOutXPass OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+        "The number of packets statefully passed out where the state
+        entry refers to the table, but the table no longer contains
+	the address in question."
+    ::= { pfTablesTblEntry 20 }
+
+pfTablesAddrTable OBJECT-TYPE
+    SYNTAX	SEQUENCE OF PfTablesAddrEntry
+    MAX-ACCESS  not-accessible
+    STATUS	current
+    DESCRIPTION
+        "Table of addresses from every table on the system."
+    ::= { pfTables 3 }
+
+pfTablesAddrEntry OBJECT-TYPE
+    SYNTAX	PfTablesAddrEntry
+    MAX-ACCESS  not-accessible
+    STATUS	current
+    DESCRIPTION
+        "An entry in the pfTablesAddrTable containing information
+        about a particular entry in a table."
+    INDEX	{ pfTablesAddrIndex }
+    ::= { pfTablesAddrTable 1 }
+
+PfTablesAddrEntry ::= SEQUENCE {
+    pfTablesAddrIndex		    Integer32,
+    pfTablesAddrNetType		    InetAddressType,
+    pfTablesAddrNet		    InetAddress,
+    pfTablesAddrPrefix		    InetAddressPrefixLength,
+    pfTablesAddrTZero		    TimeTicks,
+    pfTablesAddrBytesInPass	    Counter64,
+    pfTablesAddrBytesInBlock	    Counter64,
+    pfTablesAddrBytesOutPass	    Counter64,
+    pfTablesAddrBytesOutBlock	    Counter64,
+    pfTablesAddrPktsInPass	    Counter64,
+    pfTablesAddrPktsInBlock	    Counter64,
+    pfTablesAddrPktsOutPass	    Counter64,
+    pfTablesAddrPktsOutBlock	    Counter64
+}
+
+pfTablesAddrIndex OBJECT-TYPE
+    SYNTAX	Integer32 (1..2147483647)
+    MAX-ACCESS  not-accessible
+    STATUS	current
+    DESCRIPTION
+        "A unique value, greater than zero, for each address."
+    ::= { pfTablesAddrEntry 1 }
+
+pfTablesAddrNetType OBJECT-TYPE
+    SYNTAX	InetAddressType
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The type of address in the corresponding pfTablesAddrNet object."
+    ::= { pfTablesAddrEntry 2 }
+
+pfTablesAddrNet OBJECT-TYPE
+    SYNTAX	InetAddress
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+        "The IP address of this particular table entry."
+    ::= { pfTablesAddrEntry 3 }
+
+pfTablesAddrPrefix OBJECT-TYPE
+    SYNTAX	InetAddressPrefixLength
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+        "The CIDR netmask of this particular table entry."
+    ::= { pfTablesAddrEntry 4 }
+
+pfTablesAddrTZero OBJECT-TYPE
+    SYNTAX	TimeTicks
+    UNITS	"1/100th of a Second"
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+        "The time passed since this entry's statistics were last
+	cleared, or the time passed since this entry was loaded
+	into the table, whichever is sooner."
+    ::= { pfTablesAddrEntry 5 }
+
+pfTablesAddrBytesInPass OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+        "The number of inbound bytes passed as a result of this entry."
+    ::= { pfTablesAddrEntry 6 }
+
+pfTablesAddrBytesInBlock OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+        "The number of inbound bytes blocked as a result of this entry."
+    ::= { pfTablesAddrEntry 7 }
+
+pfTablesAddrBytesOutPass OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+        "The number of outbound bytes passed as a result of this entry."
+    ::= { pfTablesAddrEntry 8 }
+
+pfTablesAddrBytesOutBlock OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+        "The number of outbound bytes blocked as a result of this entry."
+    ::= { pfTablesAddrEntry 9 }
+
+pfTablesAddrPktsInPass OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+        "The number of inbound packets passed as a result of this entry."
+    ::= { pfTablesAddrEntry 10 }
+
+pfTablesAddrPktsInBlock OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+        "The number of inbound packets blocked as a result of this entry."
+    ::= { pfTablesAddrEntry 11 }
+
+pfTablesAddrPktsOutPass OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+        "The number of outbound packets passed as a result of this entry."
+    ::= { pfTablesAddrEntry 12 }
+
+pfTablesAddrPktsOutBlock OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS  read-only
+    STATUS	current
+    DESCRIPTION
+        "The number of outbound packets blocked as a result of this
+        entry."
+    ::= { pfTablesAddrEntry 13 }
+
+-- --------------------------------------------------------------------------
+
+--
+-- Altq information
+--
+
+pfAltqQueueNumber OBJECT-TYPE
+    SYNTAX	Unsigned32
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The number of queues in the active set."
+    ::= { pfAltq 1 }
+
+pfAltqQueueTable OBJECT-TYPE
+    SYNTAX	SEQUENCE OF PfAltqQueueEntry
+    MAX-ACCESS	not-accessible
+    STATUS	current
+    DESCRIPTION
+	"Table containing the rules that are active on this system."
+    ::= { pfAltq 2 }
+
+pfAltqQueueEntry OBJECT-TYPE
+    SYNTAX	PfAltqQueueEntry
+    MAX-ACCESS	not-accessible
+    STATUS	current
+    DESCRIPTION
+	"An entry in the pfAltqQueueTable table."
+    INDEX	{ pfAltqQueueIndex }
+    ::= { pfAltqQueueTable 1 }
+
+PfAltqQueueEntry ::= SEQUENCE {
+    pfAltqQueueIndex		    Integer32,
+    pfAltqQueueDescr		    OCTET STRING,
+    pfAltqQueueParent		    OCTET STRING,
+    pfAltqQueueScheduler	    INTEGER,
+    pfAltqQueueBandwidth	    Unsigned32,
+    pfAltqQueuePriority		    Integer32,
+    pfAltqQueueLimit		    Integer32
+}
+
+pfAltqQueueIndex OBJECT-TYPE
+    SYNTAX	Integer32 (1..2147483647)
+    MAX-ACCESS	not-accessible
+    STATUS	current
+    DESCRIPTION
+	"A unique value, greater than zero, for each queue."
+    ::= { pfAltqQueueEntry 1 }
+
+pfAltqQueueDescr OBJECT-TYPE
+    SYNTAX	OCTET STRING
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The name of the queue."
+    ::= { pfAltqQueueEntry 2 }
+
+pfAltqQueueParent OBJECT-TYPE
+    SYNTAX	OCTET STRING
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Name of the queue's parent if it has one."
+    ::= { pfAltqQueueEntry 3 }
+
+pfAltqQueueScheduler OBJECT-TYPE
+    SYNTAX	INTEGER { cbq(1), hfsc(8), priq(11) }
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Scheduler algorithm implemented by this queue."
+    ::= { pfAltqQueueEntry 4 }
+
+pfAltqQueueBandwidth OBJECT-TYPE
+    SYNTAX	Unsigned32
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Bandwitch assigned to this queue."
+    ::= { pfAltqQueueEntry 5 }
+
+pfAltqQueuePriority OBJECT-TYPE
+    SYNTAX	Integer32
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Priority level of the queue."
+    ::= { pfAltqQueueEntry 6 }
+
+pfAltqQueueLimit OBJECT-TYPE
+    SYNTAX	Integer32
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"Maximum number of packets in the queue."
+    ::= { pfAltqQueueEntry 7 }
+
+pfLabelsLblNumber OBJECT-TYPE
+    SYNTAX	Integer32
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The number of labeled filter rules on this system."
+    ::= { pfLabels 1 }
+
+pfLabelsLblTable OBJECT-TYPE
+    SYNTAX	SEQUENCE OF PfLabelsLblEntry
+    MAX-ACCESS	not-accessible
+    STATUS	current
+    DESCRIPTION
+	"Table of filter rules, index on pfLabelsLblIndex."
+    ::= { pfLabels 2 }
+
+pfLabelsLblEntry OBJECT-TYPE
+    SYNTAX	PfLabelsLblEntry
+    MAX-ACCESS	not-accessible
+    STATUS	current
+    DESCRIPTION
+	"Any entry in the pfLabelsLblTable containing information
+	about a particular filter rule on the system."
+    INDEX	{ pfLabelsLblIndex }
+    ::= { pfLabelsLblTable 1 }
+
+PfLabelsLblEntry ::= SEQUENCE {
+    pfLabelsLblIndex		Integer32,
+    pfLabelsLblName		OCTET STRING,
+    pfLabelsLblEvals		Counter64,
+    pfLabelsLblBytesIn		Counter64,
+    pfLabelsLblBytesOut		Counter64,
+    pfLabelsLblPktsIn		Counter64,
+    pfLabelsLblPktsOut		Counter64
+}
+
+pfLabelsLblIndex OBJECT-TYPE
+    SYNTAX	Integer32 (1..2147483647)
+    MAX-ACCESS	not-accessible
+    STATUS	current
+    DESCRIPTION
+	"A unique value, greater than zero, for each label."
+    ::= { pfLabelsLblEntry 1 }
+
+pfLabelsLblName OBJECT-TYPE
+    SYNTAX	OCTET STRING
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The name of the rule label."
+    ::= { pfLabelsLblEntry 2 }
+
+pfLabelsLblEvals OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The number of rule evaluations."
+    ::= { pfLabelsLblEntry 3 }
+
+pfLabelsLblBytesIn OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The number of incoming bytes matched by the rule."
+    ::= { pfLabelsLblEntry 4 }
+
+pfLabelsLblBytesOut OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The number of outgoing bytes matched by the rule."
+    ::= { pfLabelsLblEntry 5 }
+
+pfLabelsLblPktsIn OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The number of incoming packets matched by the rule."
+    ::= { pfLabelsLblEntry 6 }
+
+pfLabelsLblPktsOut OBJECT-TYPE
+    SYNTAX	Counter64
+    MAX-ACCESS	read-only
+    STATUS	current
+    DESCRIPTION
+	"The number of outgoing packets matched by the rule."
+    ::= { pfLabelsLblEntry 7 }
+
+END

--- a/dockermaster/docker/snmp-exporter/mibs/FOKUS-MIB.txt
+++ b/dockermaster/docker/snmp-exporter/mibs/FOKUS-MIB.txt
@@ -1,0 +1,63 @@
+--
+-- Copyright (c) 2001-2003
+--	Fraunhofer Institute for Open Communication Systems (FhG Fokus).
+--	All rights reserved.
+--
+-- Author: Harti Brandt <harti@freebsd.org>
+--
+-- Redistribution and use in source and binary forms, with or without
+-- modification, are permitted provided that the following conditions
+-- are met:
+-- 1. Redistributions of source code must retain the above copyright
+--    notice, this list of conditions and the following disclaimer.
+-- 2. Redistributions in binary form must reproduce the above copyright
+--    notice, this list of conditions and the following disclaimer in the
+--    documentation and/or other materials provided with the distribution.
+--
+-- THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+-- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+-- ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE LIABLE
+-- FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-- DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+-- OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+-- HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+-- LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+-- OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+-- SUCH DAMAGE.
+--
+-- Fokus PEN root module.
+--
+FOKUS-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, enterprises
+	FROM SNMPv2-SMI;
+
+fokus MODULE-IDENTITY
+    LAST-UPDATED "202304140000Z"
+    ORGANIZATION "Fraunhofer FOKUS"
+    CONTACT-INFO
+	    "		Bjoern Riemer
+
+	     Postal:	Fraunhofer Institute for Open Communication Systems
+			Kaiserin-Augusta-Allee 31
+			10589 Berlin
+			Germany
+
+	     E-mail:	iana-pen@fokus.fraunhofer.de"
+    DESCRIPTION
+	    "The root of the Fokus enterprises tree."
+    REVISION "202304140000Z"
+    DESCRIPTION
+	    "Contact info updated."
+    REVISION "200202050000Z"
+    DESCRIPTION
+	    "Initial revision."
+    ::= { enterprises 12325 }
+
+--
+-- begemot ::= fokus.1
+--	contact: hartmut.brandt@dlr.de
+--
+END

--- a/dockermaster/docker/snmp-exporter/regen.sh
+++ b/dockermaster/docker/snmp-exporter/regen.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Regenerate snmp.yml from generator.yml + MIBs in this directory.
+#
+# Output: ./snmp.yml (committed; community: stays as placeholder "public")
+# Deploy: separate step, see README.md (currently a manual scp + restart;
+#         migration to a baked image is tracked in the README's "Phase E"
+#         note).
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+# Build the helper image (idempotent; re-uses cache layers).
+docker build -f Dockerfile.generator -t local/snmp-generator-with-mibs .
+
+# Run the generator. --no-fail-on-parse-errors swallows the one harmless
+# `Bad operator (INTEGER) at line 73 in SNMPv2-PDU` warning from the
+# bundled IETF MIBs (known net-snmp parser quirk).
+docker run --rm -v "$PWD:/opt" -w /opt --entrypoint /bin/generator \
+  local/snmp-generator-with-mibs \
+  generate --no-fail-on-parse-errors -g generator.yml -o snmp.yml
+
+echo
+echo "Generated snmp.yml: $(wc -l < snmp.yml) lines, $(grep -c '^    - name:' snmp.yml) walked metrics"
+echo
+echo "Deploy: see README.md. Until baked-image migration, the runtime"
+echo "community string is injected by sed-substituting 'community: public'"
+echo "with the value from Vault path secret/homelab/pfsense/snmp during scp."

--- a/dockermaster/docker/snmp-exporter/snmp.yml
+++ b/dockermaster/docker/snmp-exporter/snmp.yml
@@ -1,0 +1,1803 @@
+# WARNING: This file was auto-generated using snmp_exporter generator, manual changes will be lost.
+auths:
+  pfsense_v2:
+    community: public
+    security_level: noAuthNoPriv
+    auth_protocol: MD5
+    priv_protocol: DES
+    version: 2
+modules:
+  pfsense:
+    walk:
+    - 1.3.6.1.2.1.2.2.1.1
+    - 1.3.6.1.2.1.2.2.1.13
+    - 1.3.6.1.2.1.2.2.1.14
+    - 1.3.6.1.2.1.2.2.1.15
+    - 1.3.6.1.2.1.2.2.1.19
+    - 1.3.6.1.2.1.2.2.1.2
+    - 1.3.6.1.2.1.2.2.1.20
+    - 1.3.6.1.2.1.2.2.1.3
+    - 1.3.6.1.2.1.2.2.1.4
+    - 1.3.6.1.2.1.2.2.1.5
+    - 1.3.6.1.2.1.2.2.1.6
+    - 1.3.6.1.2.1.2.2.1.7
+    - 1.3.6.1.2.1.2.2.1.8
+    - 1.3.6.1.2.1.2.2.1.9
+    - 1.3.6.1.2.1.25.2.3.1.2
+    - 1.3.6.1.2.1.25.2.3.1.3
+    - 1.3.6.1.2.1.25.2.3.1.4
+    - 1.3.6.1.2.1.25.2.3.1.5
+    - 1.3.6.1.2.1.25.2.3.1.6
+    - 1.3.6.1.2.1.25.2.3.1.7
+    - 1.3.6.1.2.1.25.3.2.1.2
+    - 1.3.6.1.2.1.25.3.2.1.3
+    - 1.3.6.1.2.1.25.3.2.1.5
+    - 1.3.6.1.2.1.25.3.2.1.6
+    - 1.3.6.1.2.1.25.3.3.1.2
+    - 1.3.6.1.2.1.31.1.1.1.1
+    - 1.3.6.1.2.1.31.1.1.1.10
+    - 1.3.6.1.2.1.31.1.1.1.11
+    - 1.3.6.1.2.1.31.1.1.1.12
+    - 1.3.6.1.2.1.31.1.1.1.13
+    - 1.3.6.1.2.1.31.1.1.1.15
+    - 1.3.6.1.2.1.31.1.1.1.18
+    - 1.3.6.1.2.1.31.1.1.1.2
+    - 1.3.6.1.2.1.31.1.1.1.3
+    - 1.3.6.1.2.1.31.1.1.1.4
+    - 1.3.6.1.2.1.31.1.1.1.5
+    - 1.3.6.1.2.1.31.1.1.1.6
+    - 1.3.6.1.2.1.31.1.1.1.7
+    - 1.3.6.1.2.1.31.1.1.1.8
+    - 1.3.6.1.2.1.31.1.1.1.9
+    - 1.3.6.1.4.1.12325.1.200.1.1
+    - 1.3.6.1.4.1.12325.1.200.1.2
+    - 1.3.6.1.4.1.12325.1.200.1.3
+    - 1.3.6.1.4.1.12325.1.200.1.5
+    - 1.3.6.1.4.1.12325.1.200.1.6
+    - 1.3.6.1.4.1.12325.1.200.1.7
+    - 1.3.6.1.4.1.12325.1.200.1.8
+    - 1.3.6.1.4.1.12325.1.200.1.9.2
+    get:
+    - 1.3.6.1.2.1.1.1.0
+    - 1.3.6.1.2.1.1.3.0
+    - 1.3.6.1.2.1.1.4.0
+    - 1.3.6.1.2.1.1.5.0
+    - 1.3.6.1.2.1.1.6.0
+    - 1.3.6.1.2.1.2.1.0
+    - 1.3.6.1.2.1.25.1.1.0
+    - 1.3.6.1.2.1.25.1.2.0
+    - 1.3.6.1.2.1.25.1.5.0
+    - 1.3.6.1.2.1.25.1.6.0
+    - 1.3.6.1.2.1.25.1.7.0
+    - 1.3.6.1.2.1.25.2.2.0
+    - 1.3.6.1.4.1.12325.1.200.1.9.1.0
+    metrics:
+    - name: sysDescr
+      oid: 1.3.6.1.2.1.1.1
+      type: DisplayString
+      help: A textual description of the entity - 1.3.6.1.2.1.1.1
+    - name: sysUpTime
+      oid: 1.3.6.1.2.1.1.3
+      type: gauge
+      help: The time (in hundredths of a second) since the network management portion
+        of the system was last re-initialized. - 1.3.6.1.2.1.1.3
+    - name: sysContact
+      oid: 1.3.6.1.2.1.1.4
+      type: DisplayString
+      help: The textual identification of the contact person for this managed node,
+        together with information on how to contact this person - 1.3.6.1.2.1.1.4
+    - name: sysName
+      oid: 1.3.6.1.2.1.1.5
+      type: DisplayString
+      help: An administratively-assigned name for this managed node - 1.3.6.1.2.1.1.5
+    - name: sysLocation
+      oid: 1.3.6.1.2.1.1.6
+      type: DisplayString
+      help: The physical location of this node (e.g., 'telephone closet, 3rd floor')
+        - 1.3.6.1.2.1.1.6
+    - name: ifNumber
+      oid: 1.3.6.1.2.1.2.1
+      type: gauge
+      help: The number of network interfaces (regardless of their current state) present
+        on this system. - 1.3.6.1.2.1.2.1
+    - name: ifIndex
+      oid: 1.3.6.1.2.1.2.2.1.1
+      type: gauge
+      help: A unique value, greater than zero, for each interface - 1.3.6.1.2.1.2.2.1.1
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+    - name: ifInDiscards
+      oid: 1.3.6.1.2.1.2.2.1.13
+      type: counter
+      help: The number of inbound packets which were chosen to be discarded even though
+        no errors had been detected to prevent their being deliverable to a higher-layer
+        protocol - 1.3.6.1.2.1.2.2.1.13
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+    - name: ifInErrors
+      oid: 1.3.6.1.2.1.2.2.1.14
+      type: counter
+      help: For packet-oriented interfaces, the number of inbound packets that contained
+        errors preventing them from being deliverable to a higher-layer protocol -
+        1.3.6.1.2.1.2.2.1.14
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+    - name: ifInUnknownProtos
+      oid: 1.3.6.1.2.1.2.2.1.15
+      type: counter
+      help: For packet-oriented interfaces, the number of packets received via the
+        interface which were discarded because of an unknown or unsupported protocol
+        - 1.3.6.1.2.1.2.2.1.15
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+    - name: ifOutDiscards
+      oid: 1.3.6.1.2.1.2.2.1.19
+      type: counter
+      help: The number of outbound packets which were chosen to be discarded even
+        though no errors had been detected to prevent their being transmitted - 1.3.6.1.2.1.2.2.1.19
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+    - name: ifDescr
+      oid: 1.3.6.1.2.1.2.2.1.2
+      type: DisplayString
+      help: A textual string containing information about the interface - 1.3.6.1.2.1.2.2.1.2
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+    - name: ifOutErrors
+      oid: 1.3.6.1.2.1.2.2.1.20
+      type: counter
+      help: For packet-oriented interfaces, the number of outbound packets that could
+        not be transmitted because of errors - 1.3.6.1.2.1.2.2.1.20
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+    - name: ifType
+      oid: 1.3.6.1.2.1.2.2.1.3
+      type: gauge
+      help: The type of interface - 1.3.6.1.2.1.2.2.1.3
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+      enum_values:
+        1: other
+        2: regular1822
+        3: hdh1822
+        4: ddnX25
+        5: rfc877x25
+        6: ethernetCsmacd
+        7: iso88023Csmacd
+        8: iso88024TokenBus
+        9: iso88025TokenRing
+        10: iso88026Man
+        11: starLan
+        12: proteon10Mbit
+        13: proteon80Mbit
+        14: hyperchannel
+        15: fddi
+        16: lapb
+        17: sdlc
+        18: ds1
+        19: e1
+        20: basicISDN
+        21: primaryISDN
+        22: propPointToPointSerial
+        23: ppp
+        24: softwareLoopback
+        25: eon
+        26: ethernet3Mbit
+        27: nsip
+        28: slip
+        29: ultra
+        30: ds3
+        31: sip
+        32: frameRelay
+        33: rs232
+        34: para
+        35: arcnet
+        36: arcnetPlus
+        37: atm
+        38: miox25
+        39: sonet
+        40: x25ple
+        41: iso88022llc
+        42: localTalk
+        43: smdsDxi
+        44: frameRelayService
+        45: v35
+        46: hssi
+        47: hippi
+        48: modem
+        49: aal5
+        50: sonetPath
+        51: sonetVT
+        52: smdsIcip
+        53: propVirtual
+        54: propMultiplexor
+        55: ieee80212
+        56: fibreChannel
+        57: hippiInterface
+        58: frameRelayInterconnect
+        59: aflane8023
+        60: aflane8025
+        61: cctEmul
+        62: fastEther
+        63: isdn
+        64: v11
+        65: v36
+        66: g703at64k
+        67: g703at2mb
+        68: qllc
+        69: fastEtherFX
+        70: channel
+        71: ieee80211
+        72: ibm370parChan
+        73: escon
+        74: dlsw
+        75: isdns
+        76: isdnu
+        77: lapd
+        78: ipSwitch
+        79: rsrb
+        80: atmLogical
+        81: ds0
+        82: ds0Bundle
+        83: bsc
+        84: async
+        85: cnr
+        86: iso88025Dtr
+        87: eplrs
+        88: arap
+        89: propCnls
+        90: hostPad
+        91: termPad
+        92: frameRelayMPI
+        93: x213
+        94: adsl
+        95: radsl
+        96: sdsl
+        97: vdsl
+        98: iso88025CRFPInt
+        99: myrinet
+        100: voiceEM
+        101: voiceFXO
+        102: voiceFXS
+        103: voiceEncap
+        104: voiceOverIp
+        105: atmDxi
+        106: atmFuni
+        107: atmIma
+        108: pppMultilinkBundle
+        109: ipOverCdlc
+        110: ipOverClaw
+        111: stackToStack
+        112: virtualIpAddress
+        113: mpc
+        114: ipOverAtm
+        115: iso88025Fiber
+        116: tdlc
+        117: gigabitEthernet
+        118: hdlc
+        119: lapf
+        120: v37
+        121: x25mlp
+        122: x25huntGroup
+        123: transpHdlc
+        124: interleave
+        125: fast
+        126: ip
+        127: docsCableMaclayer
+        128: docsCableDownstream
+        129: docsCableUpstream
+        130: a12MppSwitch
+        131: tunnel
+        132: coffee
+        133: ces
+        134: atmSubInterface
+        135: l2vlan
+        136: l3ipvlan
+        137: l3ipxvlan
+        138: digitalPowerline
+        139: mediaMailOverIp
+        140: dtm
+        141: dcn
+        142: ipForward
+        143: msdsl
+        144: ieee1394
+        145: if-gsn
+        146: dvbRccMacLayer
+        147: dvbRccDownstream
+        148: dvbRccUpstream
+        149: atmVirtual
+        150: mplsTunnel
+        151: srp
+        152: voiceOverAtm
+        153: voiceOverFrameRelay
+        154: idsl
+        155: compositeLink
+        156: ss7SigLink
+        157: propWirelessP2P
+        158: frForward
+        159: rfc1483
+        160: usb
+        161: ieee8023adLag
+        162: bgppolicyaccounting
+        163: frf16MfrBundle
+        164: h323Gatekeeper
+        165: h323Proxy
+        166: mpls
+        167: mfSigLink
+        168: hdsl2
+        169: shdsl
+        170: ds1FDL
+        171: pos
+        172: dvbAsiIn
+        173: dvbAsiOut
+        174: plc
+        175: nfas
+        176: tr008
+        177: gr303RDT
+        178: gr303IDT
+        179: isup
+        180: propDocsWirelessMaclayer
+        181: propDocsWirelessDownstream
+        182: propDocsWirelessUpstream
+        183: hiperlan2
+        184: propBWAp2Mp
+        185: sonetOverheadChannel
+        186: digitalWrapperOverheadChannel
+        187: aal2
+        188: radioMAC
+        189: atmRadio
+        190: imt
+        191: mvl
+        192: reachDSL
+        193: frDlciEndPt
+        194: atmVciEndPt
+        195: opticalChannel
+        196: opticalTransport
+        197: propAtm
+        198: voiceOverCable
+        199: infiniband
+        200: teLink
+        201: q2931
+        202: virtualTg
+        203: sipTg
+        204: sipSig
+        205: docsCableUpstreamChannel
+        206: econet
+        207: pon155
+        208: pon622
+        209: bridge
+        210: linegroup
+        211: voiceEMFGD
+        212: voiceFGDEANA
+        213: voiceDID
+        214: mpegTransport
+        215: sixToFour
+        216: gtp
+        217: pdnEtherLoop1
+        218: pdnEtherLoop2
+        219: opticalChannelGroup
+        220: homepna
+        221: gfp
+        222: ciscoISLvlan
+        223: actelisMetaLOOP
+        224: fcipLink
+        225: rpr
+        226: qam
+        227: lmp
+        228: cblVectaStar
+        229: docsCableMCmtsDownstream
+        230: adsl2
+        231: macSecControlledIF
+        232: macSecUncontrolledIF
+        233: aviciOpticalEther
+        234: atmbond
+        235: voiceFGDOS
+        236: mocaVersion1
+        237: ieee80216WMAN
+        238: adsl2plus
+        239: dvbRcsMacLayer
+        240: dvbTdm
+        241: dvbRcsTdma
+        242: x86Laps
+        243: wwanPP
+        244: wwanPP2
+        245: voiceEBS
+        246: ifPwType
+        247: ilan
+        248: pip
+        249: aluELP
+        250: gpon
+        251: vdsl2
+        252: capwapDot11Profile
+        253: capwapDot11Bss
+        254: capwapWtpVirtualRadio
+        255: bits
+        256: docsCableUpstreamRfPort
+        257: cableDownstreamRfPort
+        258: vmwareVirtualNic
+        259: ieee802154
+        260: otnOdu
+        261: otnOtu
+        262: ifVfiType
+        263: g9981
+        264: g9982
+        265: g9983
+        266: aluEpon
+        267: aluEponOnu
+        268: aluEponPhysicalUni
+        269: aluEponLogicalLink
+        270: aluGponOnu
+        271: aluGponPhysicalUni
+        272: vmwareNicTeam
+        277: docsOfdmDownstream
+        278: docsOfdmaUpstream
+        279: gfast
+        280: sdci
+        281: xboxWireless
+        282: fastdsl
+    - name: ifMtu
+      oid: 1.3.6.1.2.1.2.2.1.4
+      type: gauge
+      help: The size of the largest packet which can be sent/received on the interface,
+        specified in octets - 1.3.6.1.2.1.2.2.1.4
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+    - name: ifSpeed
+      oid: 1.3.6.1.2.1.2.2.1.5
+      type: gauge
+      help: An estimate of the interface's current bandwidth in bits per second -
+        1.3.6.1.2.1.2.2.1.5
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+    - name: ifPhysAddress
+      oid: 1.3.6.1.2.1.2.2.1.6
+      type: PhysAddress48
+      help: The interface's address at its protocol sub-layer - 1.3.6.1.2.1.2.2.1.6
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+    - name: ifAdminStatus
+      oid: 1.3.6.1.2.1.2.2.1.7
+      type: gauge
+      help: The desired state of the interface - 1.3.6.1.2.1.2.2.1.7
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+      enum_values:
+        1: up
+        2: down
+        3: testing
+    - name: ifOperStatus
+      oid: 1.3.6.1.2.1.2.2.1.8
+      type: gauge
+      help: The current operational state of the interface - 1.3.6.1.2.1.2.2.1.8
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+      enum_values:
+        1: up
+        2: down
+        3: testing
+        4: unknown
+        5: dormant
+        6: notPresent
+        7: lowerLayerDown
+    - name: ifLastChange
+      oid: 1.3.6.1.2.1.2.2.1.9
+      type: gauge
+      help: The value of sysUpTime at the time the interface entered its current operational
+        state - 1.3.6.1.2.1.2.2.1.9
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+    - name: hrSystemUptime
+      oid: 1.3.6.1.2.1.25.1.1
+      type: gauge
+      help: The amount of time since this host was last initialized - 1.3.6.1.2.1.25.1.1
+    - name: hrSystemDate
+      oid: 1.3.6.1.2.1.25.1.2
+      type: DateAndTime
+      help: The host's notion of the local date and time of day. - 1.3.6.1.2.1.25.1.2
+    - name: hrSystemNumUsers
+      oid: 1.3.6.1.2.1.25.1.5
+      type: gauge
+      help: The number of user sessions for which this host is storing state information
+        - 1.3.6.1.2.1.25.1.5
+    - name: hrSystemProcesses
+      oid: 1.3.6.1.2.1.25.1.6
+      type: gauge
+      help: The number of process contexts currently loaded or running on this system.
+        - 1.3.6.1.2.1.25.1.6
+    - name: hrSystemMaxProcesses
+      oid: 1.3.6.1.2.1.25.1.7
+      type: gauge
+      help: The maximum number of process contexts this system can support - 1.3.6.1.2.1.25.1.7
+    - name: hrMemorySize
+      oid: 1.3.6.1.2.1.25.2.2
+      type: gauge
+      help: The amount of physical read-write main memory, typically RAM, contained
+        by the host. - 1.3.6.1.2.1.25.2.2
+    - name: hrStorageType
+      oid: 1.3.6.1.2.1.25.2.3.1.2
+      type: OctetString
+      help: The type of storage represented by this entry. - 1.3.6.1.2.1.25.2.3.1.2
+      indexes:
+      - labelname: hrStorageIndex
+        type: gauge
+      lookups:
+      - labels:
+        - hrStorageIndex
+        labelname: hrStorageDescr
+        oid: 1.3.6.1.2.1.25.2.3.1.3
+        type: DisplayString
+    - name: hrStorageDescr
+      oid: 1.3.6.1.2.1.25.2.3.1.3
+      type: DisplayString
+      help: A description of the type and instance of the storage described by this
+        entry. - 1.3.6.1.2.1.25.2.3.1.3
+      indexes:
+      - labelname: hrStorageIndex
+        type: gauge
+      lookups:
+      - labels:
+        - hrStorageIndex
+        labelname: hrStorageDescr
+        oid: 1.3.6.1.2.1.25.2.3.1.3
+        type: DisplayString
+    - name: hrStorageAllocationUnits
+      oid: 1.3.6.1.2.1.25.2.3.1.4
+      type: gauge
+      help: The size, in bytes, of the data objects allocated from this pool - 1.3.6.1.2.1.25.2.3.1.4
+      indexes:
+      - labelname: hrStorageIndex
+        type: gauge
+      lookups:
+      - labels:
+        - hrStorageIndex
+        labelname: hrStorageDescr
+        oid: 1.3.6.1.2.1.25.2.3.1.3
+        type: DisplayString
+    - name: hrStorageSize
+      oid: 1.3.6.1.2.1.25.2.3.1.5
+      type: gauge
+      help: The size of the storage represented by this entry, in units of hrStorageAllocationUnits
+        - 1.3.6.1.2.1.25.2.3.1.5
+      indexes:
+      - labelname: hrStorageIndex
+        type: gauge
+      lookups:
+      - labels:
+        - hrStorageIndex
+        labelname: hrStorageDescr
+        oid: 1.3.6.1.2.1.25.2.3.1.3
+        type: DisplayString
+    - name: hrStorageUsed
+      oid: 1.3.6.1.2.1.25.2.3.1.6
+      type: gauge
+      help: The amount of the storage represented by this entry that is allocated,
+        in units of hrStorageAllocationUnits. - 1.3.6.1.2.1.25.2.3.1.6
+      indexes:
+      - labelname: hrStorageIndex
+        type: gauge
+      lookups:
+      - labels:
+        - hrStorageIndex
+        labelname: hrStorageDescr
+        oid: 1.3.6.1.2.1.25.2.3.1.3
+        type: DisplayString
+    - name: hrStorageAllocationFailures
+      oid: 1.3.6.1.2.1.25.2.3.1.7
+      type: counter
+      help: The number of requests for storage represented by this entry that could
+        not be honored due to not enough storage - 1.3.6.1.2.1.25.2.3.1.7
+      indexes:
+      - labelname: hrStorageIndex
+        type: gauge
+      lookups:
+      - labels:
+        - hrStorageIndex
+        labelname: hrStorageDescr
+        oid: 1.3.6.1.2.1.25.2.3.1.3
+        type: DisplayString
+    - name: hrDeviceType
+      oid: 1.3.6.1.2.1.25.3.2.1.2
+      type: OctetString
+      help: An indication of the type of device - 1.3.6.1.2.1.25.3.2.1.2
+      indexes:
+      - labelname: hrDeviceIndex
+        type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+    - name: hrDeviceDescr
+      oid: 1.3.6.1.2.1.25.3.2.1.3
+      type: DisplayString
+      help: A textual description of this device, including the device's manufacturer
+        and revision, and optionally, its serial number. - 1.3.6.1.2.1.25.3.2.1.3
+      indexes:
+      - labelname: hrDeviceIndex
+        type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+    - name: hrDeviceStatus
+      oid: 1.3.6.1.2.1.25.3.2.1.5
+      type: gauge
+      help: The current operational state of the device described by this row of the
+        table - 1.3.6.1.2.1.25.3.2.1.5
+      indexes:
+      - labelname: hrDeviceIndex
+        type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      enum_values:
+        1: unknown
+        2: running
+        3: warning
+        4: testing
+        5: down
+    - name: hrDeviceErrors
+      oid: 1.3.6.1.2.1.25.3.2.1.6
+      type: counter
+      help: The number of errors detected on this device - 1.3.6.1.2.1.25.3.2.1.6
+      indexes:
+      - labelname: hrDeviceIndex
+        type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+    - name: hrProcessorLoad
+      oid: 1.3.6.1.2.1.25.3.3.1.2
+      type: gauge
+      help: The average, over the last minute, of the percentage of time that this
+        processor was not idle - 1.3.6.1.2.1.25.3.3.1.2
+      indexes:
+      - labelname: hrDeviceIndex
+        type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+    - name: ifName
+      oid: 1.3.6.1.2.1.31.1.1.1.1
+      type: DisplayString
+      help: The textual name of the interface - 1.3.6.1.2.1.31.1.1.1.1
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+    - name: ifHCOutOctets
+      oid: 1.3.6.1.2.1.31.1.1.1.10
+      type: counter
+      help: The total number of octets transmitted out of the interface, including
+        framing characters - 1.3.6.1.2.1.31.1.1.1.10
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+    - name: ifHCOutUcastPkts
+      oid: 1.3.6.1.2.1.31.1.1.1.11
+      type: counter
+      help: The total number of packets that higher-level protocols requested be transmitted,
+        and which were not addressed to a multicast or broadcast address at this sub-layer,
+        including those that were discarded or not sent - 1.3.6.1.2.1.31.1.1.1.11
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+    - name: ifHCOutMulticastPkts
+      oid: 1.3.6.1.2.1.31.1.1.1.12
+      type: counter
+      help: The total number of packets that higher-level protocols requested be transmitted,
+        and which were addressed to a multicast address at this sub-layer, including
+        those that were discarded or not sent - 1.3.6.1.2.1.31.1.1.1.12
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+    - name: ifHCOutBroadcastPkts
+      oid: 1.3.6.1.2.1.31.1.1.1.13
+      type: counter
+      help: The total number of packets that higher-level protocols requested be transmitted,
+        and which were addressed to a broadcast address at this sub-layer, including
+        those that were discarded or not sent - 1.3.6.1.2.1.31.1.1.1.13
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+    - name: ifHighSpeed
+      oid: 1.3.6.1.2.1.31.1.1.1.15
+      type: gauge
+      help: An estimate of the interface's current bandwidth in units of 1,000,000
+        bits per second - 1.3.6.1.2.1.31.1.1.1.15
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+    - name: ifAlias
+      oid: 1.3.6.1.2.1.31.1.1.1.18
+      type: DisplayString
+      help: This object is an 'alias' name for the interface as specified by a network
+        manager, and provides a non-volatile 'handle' for the interface - 1.3.6.1.2.1.31.1.1.1.18
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+    - name: ifInMulticastPkts
+      oid: 1.3.6.1.2.1.31.1.1.1.2
+      type: counter
+      help: The number of packets, delivered by this sub-layer to a higher (sub-)layer,
+        which were addressed to a multicast address at this sub-layer - 1.3.6.1.2.1.31.1.1.1.2
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+    - name: ifInBroadcastPkts
+      oid: 1.3.6.1.2.1.31.1.1.1.3
+      type: counter
+      help: The number of packets, delivered by this sub-layer to a higher (sub-)layer,
+        which were addressed to a broadcast address at this sub-layer - 1.3.6.1.2.1.31.1.1.1.3
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+    - name: ifOutMulticastPkts
+      oid: 1.3.6.1.2.1.31.1.1.1.4
+      type: counter
+      help: The total number of packets that higher-level protocols requested be transmitted,
+        and which were addressed to a multicast address at this sub-layer, including
+        those that were discarded or not sent - 1.3.6.1.2.1.31.1.1.1.4
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+    - name: ifOutBroadcastPkts
+      oid: 1.3.6.1.2.1.31.1.1.1.5
+      type: counter
+      help: The total number of packets that higher-level protocols requested be transmitted,
+        and which were addressed to a broadcast address at this sub-layer, including
+        those that were discarded or not sent - 1.3.6.1.2.1.31.1.1.1.5
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+    - name: ifHCInOctets
+      oid: 1.3.6.1.2.1.31.1.1.1.6
+      type: counter
+      help: The total number of octets received on the interface, including framing
+        characters - 1.3.6.1.2.1.31.1.1.1.6
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+    - name: ifHCInUcastPkts
+      oid: 1.3.6.1.2.1.31.1.1.1.7
+      type: counter
+      help: The number of packets, delivered by this sub-layer to a higher (sub-)layer,
+        which were not addressed to a multicast or broadcast address at this sub-layer
+        - 1.3.6.1.2.1.31.1.1.1.7
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+    - name: ifHCInMulticastPkts
+      oid: 1.3.6.1.2.1.31.1.1.1.8
+      type: counter
+      help: The number of packets, delivered by this sub-layer to a higher (sub-)layer,
+        which were addressed to a multicast address at this sub-layer - 1.3.6.1.2.1.31.1.1.1.8
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+    - name: ifHCInBroadcastPkts
+      oid: 1.3.6.1.2.1.31.1.1.1.9
+      type: counter
+      help: The number of packets, delivered by this sub-layer to a higher (sub-)layer,
+        which were addressed to a broadcast address at this sub-layer - 1.3.6.1.2.1.31.1.1.1.9
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+    - name: pfStatusRunning
+      oid: 1.3.6.1.4.1.12325.1.200.1.1.1
+      type: gauge
+      help: True if pf is currently enabled. - 1.3.6.1.4.1.12325.1.200.1.1.1
+      enum_values:
+        1: "true"
+        2: "false"
+    - name: pfStatusRuntime
+      oid: 1.3.6.1.4.1.12325.1.200.1.1.2
+      type: gauge
+      help: Indicates how long pf has been enabled - 1.3.6.1.4.1.12325.1.200.1.1.2
+    - name: pfStatusDebug
+      oid: 1.3.6.1.4.1.12325.1.200.1.1.3
+      type: gauge
+      help: Indicates the debug level at which pf is running. - 1.3.6.1.4.1.12325.1.200.1.1.3
+      enum_values:
+        0: none
+        1: urgent
+        2: misc
+        3: loud
+    - name: pfStatusHostId
+      oid: 1.3.6.1.4.1.12325.1.200.1.1.4
+      type: OctetString
+      help: The (unique) host identifier of the machine running pf. - 1.3.6.1.4.1.12325.1.200.1.1.4
+    - name: pfCounterMatch
+      oid: 1.3.6.1.4.1.12325.1.200.1.2.1
+      type: counter
+      help: Number of packets that matched a filter rule. - 1.3.6.1.4.1.12325.1.200.1.2.1
+    - name: pfCounterBadOffset
+      oid: 1.3.6.1.4.1.12325.1.200.1.2.2
+      type: counter
+      help: Number of packets with bad offset. - 1.3.6.1.4.1.12325.1.200.1.2.2
+    - name: pfCounterFragment
+      oid: 1.3.6.1.4.1.12325.1.200.1.2.3
+      type: counter
+      help: Number of fragmented packets. - 1.3.6.1.4.1.12325.1.200.1.2.3
+    - name: pfCounterShort
+      oid: 1.3.6.1.4.1.12325.1.200.1.2.4
+      type: counter
+      help: Number of short packets. - 1.3.6.1.4.1.12325.1.200.1.2.4
+    - name: pfCounterNormalize
+      oid: 1.3.6.1.4.1.12325.1.200.1.2.5
+      type: counter
+      help: Number of normalized packets. - 1.3.6.1.4.1.12325.1.200.1.2.5
+    - name: pfCounterMemDrop
+      oid: 1.3.6.1.4.1.12325.1.200.1.2.6
+      type: counter
+      help: Number of packets dropped due to memory limitations. - 1.3.6.1.4.1.12325.1.200.1.2.6
+    - name: pfStateTableCount
+      oid: 1.3.6.1.4.1.12325.1.200.1.3.1
+      type: gauge
+      help: Number of entries in the state table. - 1.3.6.1.4.1.12325.1.200.1.3.1
+    - name: pfStateTableSearches
+      oid: 1.3.6.1.4.1.12325.1.200.1.3.2
+      type: counter
+      help: Number of searches against the state table. - 1.3.6.1.4.1.12325.1.200.1.3.2
+    - name: pfStateTableInserts
+      oid: 1.3.6.1.4.1.12325.1.200.1.3.3
+      type: counter
+      help: Number of entries inserted into the state table. - 1.3.6.1.4.1.12325.1.200.1.3.3
+    - name: pfStateTableRemovals
+      oid: 1.3.6.1.4.1.12325.1.200.1.3.4
+      type: counter
+      help: Number of entries removed from the state table. - 1.3.6.1.4.1.12325.1.200.1.3.4
+    - name: pfLimitsStates
+      oid: 1.3.6.1.4.1.12325.1.200.1.5.1
+      type: gauge
+      help: Maximum number of 'keep state' rules in the ruleset. - 1.3.6.1.4.1.12325.1.200.1.5.1
+    - name: pfLimitsSrcNodes
+      oid: 1.3.6.1.4.1.12325.1.200.1.5.2
+      type: gauge
+      help: Maximum number of 'sticky-address' or 'source-track' rules in the ruleset.
+        - 1.3.6.1.4.1.12325.1.200.1.5.2
+    - name: pfLimitsFrags
+      oid: 1.3.6.1.4.1.12325.1.200.1.5.3
+      type: gauge
+      help: Maximum number of 'scrub' rules in the ruleset. - 1.3.6.1.4.1.12325.1.200.1.5.3
+    - name: pfTimeoutsTcpFirst
+      oid: 1.3.6.1.4.1.12325.1.200.1.6.1
+      type: gauge
+      help: State after the first packet in a connection. - 1.3.6.1.4.1.12325.1.200.1.6.1
+    - name: pfTimeoutsTcpOpening
+      oid: 1.3.6.1.4.1.12325.1.200.1.6.2
+      type: gauge
+      help: State before the destination host ever sends a packet. - 1.3.6.1.4.1.12325.1.200.1.6.2
+    - name: pfTimeoutsTcpEstablished
+      oid: 1.3.6.1.4.1.12325.1.200.1.6.3
+      type: gauge
+      help: The fully established state. - 1.3.6.1.4.1.12325.1.200.1.6.3
+    - name: pfTimeoutsTcpClosing
+      oid: 1.3.6.1.4.1.12325.1.200.1.6.4
+      type: gauge
+      help: State after the first FIN has been sent. - 1.3.6.1.4.1.12325.1.200.1.6.4
+    - name: pfTimeoutsTcpFinWait
+      oid: 1.3.6.1.4.1.12325.1.200.1.6.5
+      type: gauge
+      help: State after both FINs have been exchanged and the connection is closed.
+        - 1.3.6.1.4.1.12325.1.200.1.6.5
+    - name: pfTimeoutsTcpClosed
+      oid: 1.3.6.1.4.1.12325.1.200.1.6.6
+      type: gauge
+      help: State after one endpoint sends an RST. - 1.3.6.1.4.1.12325.1.200.1.6.6
+    - name: pfTimeoutsUdpFirst
+      oid: 1.3.6.1.4.1.12325.1.200.1.6.7
+      type: gauge
+      help: State after the first packet. - 1.3.6.1.4.1.12325.1.200.1.6.7
+    - name: pfTimeoutsUdpSingle
+      oid: 1.3.6.1.4.1.12325.1.200.1.6.8
+      type: gauge
+      help: State if the source host sends more than one packet but the destination
+        host has never sent one back. - 1.3.6.1.4.1.12325.1.200.1.6.8
+    - name: pfTimeoutsUdpMultiple
+      oid: 1.3.6.1.4.1.12325.1.200.1.6.9
+      type: gauge
+      help: State if both hosts have sent packets. - 1.3.6.1.4.1.12325.1.200.1.6.9
+    - name: pfTimeoutsIcmpFirst
+      oid: 1.3.6.1.4.1.12325.1.200.1.6.10
+      type: gauge
+      help: State after the first packet. - 1.3.6.1.4.1.12325.1.200.1.6.10
+    - name: pfTimeoutsIcmpError
+      oid: 1.3.6.1.4.1.12325.1.200.1.6.11
+      type: gauge
+      help: State after an ICMP error came back in response to an ICMP packet. - 1.3.6.1.4.1.12325.1.200.1.6.11
+    - name: pfTimeoutsOtherFirst
+      oid: 1.3.6.1.4.1.12325.1.200.1.6.12
+      type: gauge
+      help: State after the first packet. - 1.3.6.1.4.1.12325.1.200.1.6.12
+    - name: pfTimeoutsOtherSingle
+      oid: 1.3.6.1.4.1.12325.1.200.1.6.13
+      type: gauge
+      help: State if the source host sends more than one packet but the destination
+        host has never sent one back. - 1.3.6.1.4.1.12325.1.200.1.6.13
+    - name: pfTimeoutsOtherMultiple
+      oid: 1.3.6.1.4.1.12325.1.200.1.6.14
+      type: gauge
+      help: State if both hosts have sent packets. - 1.3.6.1.4.1.12325.1.200.1.6.14
+    - name: pfTimeoutsFragment
+      oid: 1.3.6.1.4.1.12325.1.200.1.6.15
+      type: gauge
+      help: Seconds before an unassembled fragment is expired. - 1.3.6.1.4.1.12325.1.200.1.6.15
+    - name: pfTimeoutsInterval
+      oid: 1.3.6.1.4.1.12325.1.200.1.6.16
+      type: gauge
+      help: Interval between purging expired states and fragments. - 1.3.6.1.4.1.12325.1.200.1.6.16
+    - name: pfTimeoutsAdaptiveStart
+      oid: 1.3.6.1.4.1.12325.1.200.1.6.17
+      type: gauge
+      help: When the number of state entries exceeds this value, adaptive scaling
+        begins. - 1.3.6.1.4.1.12325.1.200.1.6.17
+    - name: pfTimeoutsAdaptiveEnd
+      oid: 1.3.6.1.4.1.12325.1.200.1.6.18
+      type: gauge
+      help: When reaching this number of state entries, all timeout values become
+        zero, effectively purging all state entries immediately. - 1.3.6.1.4.1.12325.1.200.1.6.18
+    - name: pfTimeoutsSrcNode
+      oid: 1.3.6.1.4.1.12325.1.200.1.6.19
+      type: gauge
+      help: Length of time to retain a source tracking entry after the last state
+        expires. - 1.3.6.1.4.1.12325.1.200.1.6.19
+    - name: pfLogInterfaceName
+      oid: 1.3.6.1.4.1.12325.1.200.1.7.1
+      type: OctetString
+      help: The name of the interface configured with 'set loginterface' - 1.3.6.1.4.1.12325.1.200.1.7.1
+    - name: pfLogInterfaceIp4BytesIn
+      oid: 1.3.6.1.4.1.12325.1.200.1.7.2
+      type: counter
+      help: Number of IPv4 bytes passed in on the loginterface. - 1.3.6.1.4.1.12325.1.200.1.7.2
+    - name: pfLogInterfaceIp4BytesOut
+      oid: 1.3.6.1.4.1.12325.1.200.1.7.3
+      type: counter
+      help: Number of IPv4 bytes passed out on the loginterface. - 1.3.6.1.4.1.12325.1.200.1.7.3
+    - name: pfLogInterfaceIp4PktsInPass
+      oid: 1.3.6.1.4.1.12325.1.200.1.7.4
+      type: counter
+      help: Number of IPv4 packets passed in on the loginterface. - 1.3.6.1.4.1.12325.1.200.1.7.4
+    - name: pfLogInterfaceIp4PktsInDrop
+      oid: 1.3.6.1.4.1.12325.1.200.1.7.5
+      type: counter
+      help: Number of IPv4 packets dropped coming in on the loginterface. - 1.3.6.1.4.1.12325.1.200.1.7.5
+    - name: pfLogInterfaceIp4PktsOutPass
+      oid: 1.3.6.1.4.1.12325.1.200.1.7.6
+      type: counter
+      help: Number of IPv4 packets passed out on the loginterface. - 1.3.6.1.4.1.12325.1.200.1.7.6
+    - name: pfLogInterfaceIp4PktsOutDrop
+      oid: 1.3.6.1.4.1.12325.1.200.1.7.7
+      type: counter
+      help: Number of IPv4 packets dropped going out on the loginterface. - 1.3.6.1.4.1.12325.1.200.1.7.7
+    - name: pfLogInterfaceIp6BytesIn
+      oid: 1.3.6.1.4.1.12325.1.200.1.7.8
+      type: counter
+      help: Number of IPv6 bytes passed in on the loginterface. - 1.3.6.1.4.1.12325.1.200.1.7.8
+    - name: pfLogInterfaceIp6BytesOut
+      oid: 1.3.6.1.4.1.12325.1.200.1.7.9
+      type: counter
+      help: Number of IPv6 bytes passed out on the loginterface. - 1.3.6.1.4.1.12325.1.200.1.7.9
+    - name: pfLogInterfaceIp6PktsInPass
+      oid: 1.3.6.1.4.1.12325.1.200.1.7.10
+      type: counter
+      help: Number of IPv6 packets passed in on the loginterface. - 1.3.6.1.4.1.12325.1.200.1.7.10
+    - name: pfLogInterfaceIp6PktsInDrop
+      oid: 1.3.6.1.4.1.12325.1.200.1.7.11
+      type: counter
+      help: Number of IPv6 packets dropped coming in on the loginterface. - 1.3.6.1.4.1.12325.1.200.1.7.11
+    - name: pfLogInterfaceIp6PktsOutPass
+      oid: 1.3.6.1.4.1.12325.1.200.1.7.12
+      type: counter
+      help: Number of IPv6 packets passed out on the loginterface. - 1.3.6.1.4.1.12325.1.200.1.7.12
+    - name: pfLogInterfaceIp6PktsOutDrop
+      oid: 1.3.6.1.4.1.12325.1.200.1.7.13
+      type: counter
+      help: Number of IPv6 packets dropped going out on the loginterface. - 1.3.6.1.4.1.12325.1.200.1.7.13
+    - name: pfInterfacesIfNumber
+      oid: 1.3.6.1.4.1.12325.1.200.1.8.1
+      type: gauge
+      help: The number of network interfaces on this system. - 1.3.6.1.4.1.12325.1.200.1.8.1
+    - name: pfInterfacesIfIndex
+      oid: 1.3.6.1.4.1.12325.1.200.1.8.2.1.1
+      type: gauge
+      help: A unique value, greater than zero, for each interface. - 1.3.6.1.4.1.12325.1.200.1.8.2.1.1
+      indexes:
+      - labelname: pfInterfacesIfIndex
+        type: gauge
+    - name: pfInterfacesIfDescr
+      oid: 1.3.6.1.4.1.12325.1.200.1.8.2.1.2
+      type: OctetString
+      help: The name of the interface. - 1.3.6.1.4.1.12325.1.200.1.8.2.1.2
+      indexes:
+      - labelname: pfInterfacesIfIndex
+        type: gauge
+    - name: pfInterfacesIfType
+      oid: 1.3.6.1.4.1.12325.1.200.1.8.2.1.3
+      type: gauge
+      help: Indicates whether the interface is a group inteface, an interface instance,
+        or whether it has been removed or destroyed. - 1.3.6.1.4.1.12325.1.200.1.8.2.1.3
+      indexes:
+      - labelname: pfInterfacesIfIndex
+        type: gauge
+      enum_values:
+        0: group
+        1: instance
+        2: detached
+    - name: pfInterfacesIfTZero
+      oid: 1.3.6.1.4.1.12325.1.200.1.8.2.1.4
+      type: gauge
+      help: Time since statistics were last reset or since the interface was loaded.
+        - 1.3.6.1.4.1.12325.1.200.1.8.2.1.4
+      indexes:
+      - labelname: pfInterfacesIfIndex
+        type: gauge
+    - name: pfInterfacesIfRefsState
+      oid: 1.3.6.1.4.1.12325.1.200.1.8.2.1.5
+      type: gauge
+      help: The number of state and/or source track entries referencing this interface.
+        - 1.3.6.1.4.1.12325.1.200.1.8.2.1.5
+      indexes:
+      - labelname: pfInterfacesIfIndex
+        type: gauge
+    - name: pfInterfacesIfRefsRule
+      oid: 1.3.6.1.4.1.12325.1.200.1.8.2.1.6
+      type: gauge
+      help: The number of rules referencing this interface. - 1.3.6.1.4.1.12325.1.200.1.8.2.1.6
+      indexes:
+      - labelname: pfInterfacesIfIndex
+        type: gauge
+    - name: pfInterfacesIf4BytesInPass
+      oid: 1.3.6.1.4.1.12325.1.200.1.8.2.1.7
+      type: counter
+      help: The number of IPv4 bytes passed coming in on this interface. - 1.3.6.1.4.1.12325.1.200.1.8.2.1.7
+      indexes:
+      - labelname: pfInterfacesIfIndex
+        type: gauge
+    - name: pfInterfacesIf4BytesInBlock
+      oid: 1.3.6.1.4.1.12325.1.200.1.8.2.1.8
+      type: counter
+      help: The number of IPv4 bytes blocked coming in on this interface. - 1.3.6.1.4.1.12325.1.200.1.8.2.1.8
+      indexes:
+      - labelname: pfInterfacesIfIndex
+        type: gauge
+    - name: pfInterfacesIf4BytesOutPass
+      oid: 1.3.6.1.4.1.12325.1.200.1.8.2.1.9
+      type: counter
+      help: The number of IPv4 bytes passed going out on this interface. - 1.3.6.1.4.1.12325.1.200.1.8.2.1.9
+      indexes:
+      - labelname: pfInterfacesIfIndex
+        type: gauge
+    - name: pfInterfacesIf4BytesOutBlock
+      oid: 1.3.6.1.4.1.12325.1.200.1.8.2.1.10
+      type: counter
+      help: The number of IPv4 bytes blocked going out on this interface. - 1.3.6.1.4.1.12325.1.200.1.8.2.1.10
+      indexes:
+      - labelname: pfInterfacesIfIndex
+        type: gauge
+    - name: pfInterfacesIf4PktsInPass
+      oid: 1.3.6.1.4.1.12325.1.200.1.8.2.1.11
+      type: counter
+      help: The number of IPv4 packets passed coming in on this interface. - 1.3.6.1.4.1.12325.1.200.1.8.2.1.11
+      indexes:
+      - labelname: pfInterfacesIfIndex
+        type: gauge
+    - name: pfInterfacesIf4PktsInBlock
+      oid: 1.3.6.1.4.1.12325.1.200.1.8.2.1.12
+      type: counter
+      help: The number of IPv4 packets blocked coming in on this interface. - 1.3.6.1.4.1.12325.1.200.1.8.2.1.12
+      indexes:
+      - labelname: pfInterfacesIfIndex
+        type: gauge
+    - name: pfInterfacesIf4PktsOutPass
+      oid: 1.3.6.1.4.1.12325.1.200.1.8.2.1.13
+      type: counter
+      help: The number of IPv4 packets passed going out on this interface. - 1.3.6.1.4.1.12325.1.200.1.8.2.1.13
+      indexes:
+      - labelname: pfInterfacesIfIndex
+        type: gauge
+    - name: pfInterfacesIf4PktsOutBlock
+      oid: 1.3.6.1.4.1.12325.1.200.1.8.2.1.14
+      type: counter
+      help: The number of IPv4 packets blocked going out on this interface. - 1.3.6.1.4.1.12325.1.200.1.8.2.1.14
+      indexes:
+      - labelname: pfInterfacesIfIndex
+        type: gauge
+    - name: pfInterfacesIf6BytesInPass
+      oid: 1.3.6.1.4.1.12325.1.200.1.8.2.1.15
+      type: counter
+      help: The number of IPv6 bytes passed coming in on this interface. - 1.3.6.1.4.1.12325.1.200.1.8.2.1.15
+      indexes:
+      - labelname: pfInterfacesIfIndex
+        type: gauge
+    - name: pfInterfacesIf6BytesInBlock
+      oid: 1.3.6.1.4.1.12325.1.200.1.8.2.1.16
+      type: counter
+      help: The number of IPv6 bytes blocked coming in on this interface. - 1.3.6.1.4.1.12325.1.200.1.8.2.1.16
+      indexes:
+      - labelname: pfInterfacesIfIndex
+        type: gauge
+    - name: pfInterfacesIf6BytesOutPass
+      oid: 1.3.6.1.4.1.12325.1.200.1.8.2.1.17
+      type: counter
+      help: The number of IPv6 bytes passed going out on this interface. - 1.3.6.1.4.1.12325.1.200.1.8.2.1.17
+      indexes:
+      - labelname: pfInterfacesIfIndex
+        type: gauge
+    - name: pfInterfacesIf6BytesOutBlock
+      oid: 1.3.6.1.4.1.12325.1.200.1.8.2.1.18
+      type: counter
+      help: The number of IPv6 bytes blocked going out on this interface. - 1.3.6.1.4.1.12325.1.200.1.8.2.1.18
+      indexes:
+      - labelname: pfInterfacesIfIndex
+        type: gauge
+    - name: pfInterfacesIf6PktsInPass
+      oid: 1.3.6.1.4.1.12325.1.200.1.8.2.1.19
+      type: counter
+      help: The number of IPv6 packets passed coming in on this interface. - 1.3.6.1.4.1.12325.1.200.1.8.2.1.19
+      indexes:
+      - labelname: pfInterfacesIfIndex
+        type: gauge
+    - name: pfInterfacesIf6PktsInBlock
+      oid: 1.3.6.1.4.1.12325.1.200.1.8.2.1.20
+      type: counter
+      help: The number of IPv6 packets blocked coming in on this interface. - 1.3.6.1.4.1.12325.1.200.1.8.2.1.20
+      indexes:
+      - labelname: pfInterfacesIfIndex
+        type: gauge
+    - name: pfInterfacesIf6PktsOutPass
+      oid: 1.3.6.1.4.1.12325.1.200.1.8.2.1.21
+      type: counter
+      help: The number of IPv6 packets passed going out on this interface. - 1.3.6.1.4.1.12325.1.200.1.8.2.1.21
+      indexes:
+      - labelname: pfInterfacesIfIndex
+        type: gauge
+    - name: pfInterfacesIf6PktsOutBlock
+      oid: 1.3.6.1.4.1.12325.1.200.1.8.2.1.22
+      type: counter
+      help: The number of IPv6 packets blocked going out on this interface. - 1.3.6.1.4.1.12325.1.200.1.8.2.1.22
+      indexes:
+      - labelname: pfInterfacesIfIndex
+        type: gauge
+    - name: pfTablesTblNumber
+      oid: 1.3.6.1.4.1.12325.1.200.1.9.1
+      type: gauge
+      help: The number of tables on this system. - 1.3.6.1.4.1.12325.1.200.1.9.1
+    - name: pfTablesTblIndex
+      oid: 1.3.6.1.4.1.12325.1.200.1.9.2.1.1
+      type: gauge
+      help: A unique value, greater than zero, for each table. - 1.3.6.1.4.1.12325.1.200.1.9.2.1.1
+      indexes:
+      - labelname: pfTablesTblIndex
+        type: gauge
+    - name: pfTablesTblDescr
+      oid: 1.3.6.1.4.1.12325.1.200.1.9.2.1.2
+      type: OctetString
+      help: The name of the table. - 1.3.6.1.4.1.12325.1.200.1.9.2.1.2
+      indexes:
+      - labelname: pfTablesTblIndex
+        type: gauge
+    - name: pfTablesTblCount
+      oid: 1.3.6.1.4.1.12325.1.200.1.9.2.1.3
+      type: gauge
+      help: The number of addresses in the table. - 1.3.6.1.4.1.12325.1.200.1.9.2.1.3
+      indexes:
+      - labelname: pfTablesTblIndex
+        type: gauge
+    - name: pfTablesTblTZero
+      oid: 1.3.6.1.4.1.12325.1.200.1.9.2.1.4
+      type: gauge
+      help: The time passed since the statistics of this table were last cleared or
+        the time since this table was loaded, whichever is sooner. - 1.3.6.1.4.1.12325.1.200.1.9.2.1.4
+      indexes:
+      - labelname: pfTablesTblIndex
+        type: gauge
+    - name: pfTablesTblRefsAnchor
+      oid: 1.3.6.1.4.1.12325.1.200.1.9.2.1.5
+      type: gauge
+      help: The number of anchors referencing this table. - 1.3.6.1.4.1.12325.1.200.1.9.2.1.5
+      indexes:
+      - labelname: pfTablesTblIndex
+        type: gauge
+    - name: pfTablesTblRefsRule
+      oid: 1.3.6.1.4.1.12325.1.200.1.9.2.1.6
+      type: gauge
+      help: The number of rules referencing this table. - 1.3.6.1.4.1.12325.1.200.1.9.2.1.6
+      indexes:
+      - labelname: pfTablesTblIndex
+        type: gauge
+    - name: pfTablesTblEvalMatch
+      oid: 1.3.6.1.4.1.12325.1.200.1.9.2.1.7
+      type: counter
+      help: The number of evaluations returning a match. - 1.3.6.1.4.1.12325.1.200.1.9.2.1.7
+      indexes:
+      - labelname: pfTablesTblIndex
+        type: gauge
+    - name: pfTablesTblEvalNoMatch
+      oid: 1.3.6.1.4.1.12325.1.200.1.9.2.1.8
+      type: counter
+      help: The number of evaluations not returning a match. - 1.3.6.1.4.1.12325.1.200.1.9.2.1.8
+      indexes:
+      - labelname: pfTablesTblIndex
+        type: gauge
+    - name: pfTablesTblBytesInPass
+      oid: 1.3.6.1.4.1.12325.1.200.1.9.2.1.9
+      type: counter
+      help: The number of bytes passed in matching the table. - 1.3.6.1.4.1.12325.1.200.1.9.2.1.9
+      indexes:
+      - labelname: pfTablesTblIndex
+        type: gauge
+    - name: pfTablesTblBytesInBlock
+      oid: 1.3.6.1.4.1.12325.1.200.1.9.2.1.10
+      type: counter
+      help: The number of bytes blocked coming in matching the table. - 1.3.6.1.4.1.12325.1.200.1.9.2.1.10
+      indexes:
+      - labelname: pfTablesTblIndex
+        type: gauge
+    - name: pfTablesTblBytesInXPass
+      oid: 1.3.6.1.4.1.12325.1.200.1.9.2.1.11
+      type: counter
+      help: The number of bytes statefully passed in where the state entry refers
+        to the table, but the table no longer contains the address in question. -
+        1.3.6.1.4.1.12325.1.200.1.9.2.1.11
+      indexes:
+      - labelname: pfTablesTblIndex
+        type: gauge
+    - name: pfTablesTblBytesOutPass
+      oid: 1.3.6.1.4.1.12325.1.200.1.9.2.1.12
+      type: counter
+      help: The number of bytes passed out matching the table. - 1.3.6.1.4.1.12325.1.200.1.9.2.1.12
+      indexes:
+      - labelname: pfTablesTblIndex
+        type: gauge
+    - name: pfTablesTblBytesOutBlock
+      oid: 1.3.6.1.4.1.12325.1.200.1.9.2.1.13
+      type: counter
+      help: The number of bytes blocked going out matching the table. - 1.3.6.1.4.1.12325.1.200.1.9.2.1.13
+      indexes:
+      - labelname: pfTablesTblIndex
+        type: gauge
+    - name: pfTablesTblBytesOutXPass
+      oid: 1.3.6.1.4.1.12325.1.200.1.9.2.1.14
+      type: counter
+      help: The number of bytes statefully passed out where the state entry refers
+        to the table, but the table no longer contains the address in question. -
+        1.3.6.1.4.1.12325.1.200.1.9.2.1.14
+      indexes:
+      - labelname: pfTablesTblIndex
+        type: gauge
+    - name: pfTablesTblPktsInPass
+      oid: 1.3.6.1.4.1.12325.1.200.1.9.2.1.15
+      type: counter
+      help: The number of packets passed in matching the table. - 1.3.6.1.4.1.12325.1.200.1.9.2.1.15
+      indexes:
+      - labelname: pfTablesTblIndex
+        type: gauge
+    - name: pfTablesTblPktsInBlock
+      oid: 1.3.6.1.4.1.12325.1.200.1.9.2.1.16
+      type: counter
+      help: The number of packets blocked coming in matching the table. - 1.3.6.1.4.1.12325.1.200.1.9.2.1.16
+      indexes:
+      - labelname: pfTablesTblIndex
+        type: gauge
+    - name: pfTablesTblPktsInXPass
+      oid: 1.3.6.1.4.1.12325.1.200.1.9.2.1.17
+      type: counter
+      help: The number of packets statefully passed in where the state entry refers
+        to the table, but the table no longer contains the address in question. -
+        1.3.6.1.4.1.12325.1.200.1.9.2.1.17
+      indexes:
+      - labelname: pfTablesTblIndex
+        type: gauge
+    - name: pfTablesTblPktsOutPass
+      oid: 1.3.6.1.4.1.12325.1.200.1.9.2.1.18
+      type: counter
+      help: The number of packets passed out matching the table. - 1.3.6.1.4.1.12325.1.200.1.9.2.1.18
+      indexes:
+      - labelname: pfTablesTblIndex
+        type: gauge
+    - name: pfTablesTblPktsOutBlock
+      oid: 1.3.6.1.4.1.12325.1.200.1.9.2.1.19
+      type: counter
+      help: The number of packets blocked going out matching the table. - 1.3.6.1.4.1.12325.1.200.1.9.2.1.19
+      indexes:
+      - labelname: pfTablesTblIndex
+        type: gauge
+    - name: pfTablesTblPktsOutXPass
+      oid: 1.3.6.1.4.1.12325.1.200.1.9.2.1.20
+      type: counter
+      help: The number of packets statefully passed out where the state entry refers
+        to the table, but the table no longer contains the address in question. -
+        1.3.6.1.4.1.12325.1.200.1.9.2.1.20
+      indexes:
+      - labelname: pfTablesTblIndex
+        type: gauge


### PR DESCRIPTION
## Summary

Closes the long-standing TODO from `generated/prometheus-thanos-monitoring/PHASE-3-REVIEW.md` and `05-exporters.md` ("run `snmp_exporter generator` against the pfSense MIB to produce a fresh module").

The current snmp.yml bind-mounted at `/nfs/dockermaster/docker/snmp-exporter/snmp.yml` (17,502 lines) is a hand-migration of a v0.20-era config that walks Raritan PDU + printer MIBs pfSense doesn't even respond to. This PR replaces it with a generator-produced config tailored to what FreeBSD's `bsnmpd` (with `mibII`, `pf`, `hostres` modules — already loaded on pfSense.home.lcamaral.com) actually exposes.

## What's added

Under `dockermaster/docker/snmp-exporter/`:

| File | Purpose |
|---|---|
| `generator.yml` | walk list + lookups + auths, the source of truth |
| `mibs/{BEGEMOT-MIB,BEGEMOT-PF-MIB,FOKUS-MIB}.txt` | non-IETF MIBs pulled from `/usr/share/snmp/mibs/` on pfSense |
| `Dockerfile.generator` | helper image: upstream snmp-generator + Debian's `snmp-mibs-downloader` (non-free IETF tree) + the BEGEMOT MIBs |
| `regen.sh` | one-shot regen wrapper |
| `snmp.yml` | generator output, committed for diff-review (community string is placeholder `public`) |
| `README.md` | module walkthrough, deliberately-skipped subtrees, deploy procedure, Phase E migration plan |

## Module coverage

| Layer | What we now collect |
|---|---|
| **System identity** | sys{UpTime,Name,Descr,Contact,Location} |
| **Interfaces (IF-MIB)** | ifTable + ifXTable, 64-bit `ifHC*` counters, with `ifName`/`ifAlias` lookups |
| **Host (HOST-RESOURCES-MIB)** | hrSystemUptime, hrSystemProcesses, hrMemorySize, hrStorage{Type,Descr,Size,Used,...}, hrDevice*, hrProcessorLoad |
| **PF firewall (BEGEMOT-PF-MIB)** | pfStatus, pfCounter (Match/BadOffset/Fragment/MemDrop/...), pfStateTable (Count + insert/remove/search rates), pfLimits (capacity), pfTimeouts, pfLogInterface, pfInterfaces (per-iface block/pass byte/pkt counters), pfTablesTbl{Number,Table} (per-table summaries) |

## Deliberately skipped (would explode scrape size or are noise)

- `pfTablesAddrTable` — per-IP entries inside each PF table (~3,000 IPs × 12 columns = **36k metric lines** from bogon/abuser/RFC1918 lists)
- `pfSrcNodes` — per-source-IP, can also explode under load
- `pfAltq` — Altq queues (deprecated on pfSense, all 0)
- `pfLabels` — per-PF-rule label counters (niche)
- `hrSWRun*` — full process table (~128 entries with hex-encoded names from a bsnmpd quirk)
- `UCD-SNMP-MIB` (laTable / systemStats / memory / dskTable) — pfSense uses `bsnmpd`, not `net-snmp`

## Verification (live test)

Spun up a throwaway `snmp-exporter` container on `docker-servers-net` with the new snmp.yml and the real Vault community string substituted in:

```text
$ curl ... '/snmp?module=pfsense&auth=pfsense_v2&target=192.168.48.1' | wc -l
7702

# Key metrics flowing:
pfStateTableCount = 10,483        # active firewall states
pfStatusRunning = 1               # PF daemon up
pfCounterMatch = 100,494,787      # cumulative pkt matches since boot
pfLimitsStates = 1,609,000        # state-table capacity
hrMemorySize = 16,482,760         # x 1KB allocation = ~16GB ✓
hrSystemUptime = 234,272,275      # ticks (~27d)
hrSystemProcesses = 115
hrProcessorLoad{cpu0..cpu7} = 1-2  # per-core load
```

Compare to today's bloated config: 854 lines of useful metrics out of 17,502 lines of snmp.yml plus ~36k lines of pfTablesAddr noise on a full walk.

## What this PR does NOT do

- **Does NOT deploy.** The snmp.yml here has community `public` (placeholder). Per the IaC-first principle (memory: `feedback_iac_first_principle.md`), I deliberately did not run `scp + docker restart` to replace `/nfs/dockermaster/docker/snmp-exporter/snmp.yml`. Deploy procedure is documented in the new README; bigger Phase E migration to a baked image is tracked there too.
- **Does NOT change `snmp_exporter.yml` stack file.** The bind-mount path is unchanged; image is still `quay.io/prometheus/snmp-exporter:v0.30.1`.

## Test plan

- [ ] `pre-commit run --all-files` — clean (passes locally).
- [ ] `terraform plan` in `terraform/portainer/` — should show **no changes** (this PR is repo content, not a terraform-managed resource yet).
- [ ] After merge, deploy:
  - `vault kv get -field=community secret/homelab/pfsense/snmp` → `$COMMUNITY`
  - `sed "s/community: public/community: $COMMUNITY/" snmp.yml > /tmp/snmp.yml.deploy`
  - `scp /tmp/snmp.yml.deploy 192.168.48.45:/nfs/dockermaster/docker/snmp-exporter/snmp.yml`
  - `ssh 192.168.48.45 'docker restart snmp-exporter-snmp-exporter-1'`
  - `rm /tmp/snmp.yml.deploy`
- [ ] Verify `snmp-pfsense` Prometheus target stays UP.
- [ ] Spot-check a query: `pfStateTableCount{instance="pfsense"}` returns a number; `hrMemorySize{instance="pfsense"}` returns a number.

## Follow-up (Phase E)

Migrate to a baked snmp-exporter image so the runtime config is built into the image at registry time, dropping the `/nfs` bind-mount and making the deploy a pure `terraform apply` (per the IaC-first principle). Detailed plan in the new README.