### PR TITLE
chore(ci): allow deps and deps-dev commit scopes

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -165,7 +165,9 @@
         "monitoring",
         "backup",
         "network",
-        "storage"
+        "storage",
+        "deps",
+        "deps-dev"
       ]
     ],
     "subject-case": [


### PR DESCRIPTION
## Summary
- Add `deps` and `deps-dev` to the commitlint `scope-enum` allowlist
- Unblocks every Dependabot PR (9 currently open all failing on Commit Message Validation)

## Why
Dependabot writes commits with `chore(deps):` and `chore(deps-dev):` scopes by default; the per-ecosystem `commit-message.prefix` knob only changes the type, not the scope. Adding both scopes is the path of least friction.

## Test plan
- [x] commitlint validates the local commit (the commit message itself uses `chore(ci):`, but verifies the new allowlist still lints)
- [ ] Re-run CI on PRs #22-#30 — they should now pass Commit Message Validation