### PR TITLE
chore(ci): drop dependabot include:scope to satisfy commitlint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,7 +35,6 @@ updates:
     commit-message:
       prefix: "chore"
       prefix-development: "chore"
-      include: "scope"
     labels:
       - "dependencies"
       - "github-actions"
@@ -58,7 +57,6 @@ updates:
     commit-message:
       prefix: "chore"
       prefix-development: "chore"
-      include: "scope"
     labels:
       - "dependencies"
       - "docker"
@@ -93,7 +91,6 @@ updates:
     commit-message:
       prefix: "chore"
       prefix-development: "chore"
-      include: "scope"
     labels:
       - "dependencies"
       - "docker"
@@ -110,7 +107,6 @@ updates:
     commit-message:
       prefix: "chore"
       prefix-development: "chore"
-      include: "scope"
     labels:
       - "dependencies"
       - "javascript"
@@ -137,7 +133,6 @@ updates:
     commit-message:
       prefix: "chore"
       prefix-development: "chore"
-      include: "scope"
     labels:
       - "dependencies"
       - "python"


### PR DESCRIPTION
## Summary
Drop \`include: \"scope\"\` from each ecosystem block in \`.github/dependabot.yml\` so Dependabot writes \`chore: bump X\` instead of \`chore(deps): bump X\`. The commitlint scope-enum allowlist intentionally enumerates homelab domains and rejects \`deps\`/\`deps-dev\`; this keeps that allowlist strict.

## Why this approach
Considered the alternative — adding \`deps\` and \`deps-dev\` to the scope-enum (PR #36, since closed) — but the allowlist is meant to describe *what part of this homelab* a change touches, not *what tooling category* a change came from. Dropping the scope keeps the rule's semantics clean.

The package name stays in the subject (e.g., "chore: bump appleboy/ssh-action from 1.0.0 to 1.2.5"), so no signal is lost.

## Test plan
- [x] Local commitlint validates the commit message
- [ ] After merge: comment \`@dependabot recreate\` on PRs #22-#30 to regenerate them with the new commit-message shape, then merge each as CI goes green