### PR TITLE
fix(monitoring): run thanos-sidecar-1 as nobody:nobody to ship blocks

### DIFF
--- a/terraform/portainer/stacks/prometheus.yml.tftpl
+++ b/terraform/portainer/stacks/prometheus.yml.tftpl
@@ -164,6 +164,14 @@ services:
   thanos-sidecar-1:
     image: quay.io/thanos/thanos:v0.41.0
     hostname: thanos-sidecar-1
+    # Run as the same UID/GID as Prometheus owns the shared TSDB volume —
+    # the upstream Thanos image defaults to uid=1001(thanos), but
+    # prometheus-1 writes to /prometheus as uid=65534(nobody). Without
+    # this override the sidecar can READ the existing blocks but can't
+    # `mkdir /prometheus/thanos` for upload staging, so every block
+    # ships nothing ("create upload dir: permission denied"). Bucket
+    # stayed empty for 13+ days before this fix.
+    user: "65534:65534"
     networks:
       servers-net:
         ipv4_address: 192.168.59.20


### PR DESCRIPTION
## Summary

Fixes the 13-day sidecar shipping outage diagnosed earlier in this work cycle. The `quay.io/thanos/thanos:v0.41.0` image defaults to uid=1001(thanos), but Prometheus writes `/prometheus` as uid=65534(nobody). Sidecar can READ blocks but can't `mkdir /prometheus/thanos` for upload staging — every shipper attempt errors with `permission denied`, MinIO `thanos` bucket has been at **0 objects / 0 bytes since 2026-04-25**.

## Diff

A 1-line `user: "65534:65534"` override on the `thanos-sidecar-1` service in `terraform/portainer/stacks/prometheus.yml.tftpl`.

```yaml
  thanos-sidecar-1:
    image: quay.io/thanos/thanos:v0.41.0
    hostname: thanos-sidecar-1
+   user: "65534:65534"   # match prometheus's nobody:nobody on shared TSDB
    networks: ...
```

## Plan

```text
$ terraform plan
  # portainer_stack.prometheus will be updated in-place
Plan: 0 to add, 1 to change, 0 to destroy.
```

## Deploy

Per memory `feedback_portainer_stack_redeploy.md`, the Portainer terraform provider updates the stored stack definition but does NOT recreate the running container on a `user:` change — same gotcha as the configs:-only changes from PR #33. So:

1. `terraform apply`
2. Trigger Portainer stack stop+start via API (`POST /api/stacks/142/{stop,start}`)
3. Verify `docker logs prometheus-thanos-sidecar-1-1` no longer shows the upload-error loop
4. Verify `mc ls local/thanos/` on minio-1 starts showing ULID directories

## Out of scope (follow-up)

- **thanos-sidecar-2 on NAS** — bind-mounts `/volume2/docker/prometheus-2/data` as read-only; host filesystem ownership unknown. Likely needs a similar `user:` override but tied to whatever DSM uid owns that path. Investigate separately after sidecar-1 is shipping.
- **Compactor + Ruler stand-up** — gated on this fix; once the bucket starts filling, deploy `thanos-compact` and `thanos-rule` on ds-2 per the Phase 1 design.

## Test plan

- [ ] `terraform apply` clean
- [ ] Portainer stack redeploy, container `Up <Xs> (healthy)`, started time updates
- [ ] `docker exec prometheus-thanos-sidecar-1-1 ls -la /prometheus/thanos/` succeeds (was permission denied)
- [ ] Within 5 minutes: `docker logs ... | grep "upload new block"` shows `uploaded=1` not `uploaded=0`
- [ ] Within 30 minutes: `mc du local/thanos` reports non-zero size on minio-1
- [ ] No regression on existing prometheus-1 scrapes (still 66 active targets, 65 UP)