### PR TITLE
fix(monitoring): flip thanos-sidecar-2 mount RO->RW so it can ship

### DIFF
--- a/terraform/portainer/stacks/prometheus-2.yml.tftpl
+++ b/terraform/portainer/stacks/prometheus-2.yml.tftpl
@@ -162,9 +162,17 @@ services:
       - --grpc-address=0.0.0.0:10901
       - --http-address=0.0.0.0:10902
     volumes:
-      # Same TSDB directory as prometheus-2, mounted read-only. The
-      # sidecar only ships completed blocks; it never writes.
-      - /volume2/docker/prometheus-2/data:/prometheus:ro
+      # Same TSDB directory as prometheus-2, mounted RW. The sidecar's
+      # shipper writes `thanos.shipper.json` bookkeeping in the TSDB
+      # root and creates a `thanos/` upload-staging dir — the original
+      # `:ro` comment ("only ships completed blocks; never writes") was
+      # wrong about the shipper internals. Production logs showed
+      # "create upload dir: read-only file system" every 30s for 13+
+      # days as a result. Same root cause as sidecar-1's UID issue
+      # (fixed in PR #42), but here it's the mount mode rather than
+      # the UID — the NAS path is owned 1027:users with 0777 perms so
+      # any UID can write once the mount is RW.
+      - /volume2/docker/prometheus-2/data:/prometheus:rw
     configs:
       - source: objstore_yml
         target: /etc/thanos/objstore.yml


### PR DESCRIPTION
## Summary

Companion to #42 (sidecar-1 UID fix). Sidecar-2 on the NAS has been silently failing for 13+ days too — but with a different root cause: the volume mount is `:ro` so the shipper can't `mkdir /prometheus/thanos` for upload staging or write `thanos.shipper.json` bookkeeping.

Confirmed via Portainer-API exec into the container:

```text
err="upload 01KQPA61FDXKMKSE850CWG6M6X: create upload dir:
     mkdir /prometheus/thanos: read-only file system" uploaded=0
```

The original `:ro` comment ("only ships completed blocks; never writes") was wrong about the shipper internals — the bookkeeping write is mandatory.

## What this PR changes

A 1-line mode flip on the sidecar-2 volume mount in `terraform/portainer/stacks/prometheus-2.yml.tftpl`:

```yaml
  thanos-sidecar-2:
    volumes:
-     - /volume2/docker/prometheus-2/data:/prometheus:ro
+     - /volume2/docker/prometheus-2/data:/prometheus:rw
```

UID is **not** an issue here unlike sidecar-1: the NAS bind-mount path `/volume2/docker/prometheus-2/data` is owned `1027:users` with `0777` perms, so any UID can write once the mount is RW.

## Out-of-band operational fix already done

The `thanos` MinIO svcaccount existed on minio-1 but **NOT on minio-2** — MinIO site-replication v1 doesn't sync svcaccounts. nginx-rproxy load-balances `s3.d.lcamaral.com` between both backends, so requests landing on minio-2 were failing with `Access Key Id you provided does not exist`. Recreated the same svcacct + policy on minio-2 manually:

```bash
mc admin accesskey create local admin \
  --access-key <vault:secret/homelab/thanos/s3#access_key> \
  --secret-key <vault:secret/homelab/thanos/s3#secret_key> \
  --name thanos --policy /tmp/thanos-policy.json
```

Same policy as minio-1: `ListBucket` / `GetObject` / `PutObject` / `DeleteObject` / `GetBucketLocation` on `arn:aws:s3:::thanos[/*]`. Tracked as a separate IaC follow-up.

## Test plan

- [ ] `terraform apply` shows `~ portainer_stack.prometheus_2 will be updated in-place`, 0 add, 0 destroy.
- [ ] `./scripts/portainer-redeploy.py prometheus-2` successfully recreates sidecar-2 container.
- [ ] sidecar-2 logs no longer show `read-only file system`.
- [ ] Within 5 min: `mc ls local/thanos/` on minio-1 (or minio-2) shows new ULID directories with `replica=B` external label (vs sidecar-1's `replica=A`).
- [ ] Existing snmp-pfsense + alertmanager + sidecar-1 scrapes unaffected.