### PR TITLE
fix(monitoring): also pin thanos-sidecar-2 to nobody UID

### DIFF
--- a/terraform/portainer/stacks/prometheus-2.yml.tftpl
+++ b/terraform/portainer/stacks/prometheus-2.yml.tftpl
@@ -147,6 +147,16 @@ services:
   thanos-sidecar-2:
     image: quay.io/thanos/thanos:v0.41.0
     hostname: thanos-sidecar-2
+    # Same UID as prometheus-2 (nobody / 65534). Needed because the
+    # shipper hardlinks block files into /prometheus/thanos/upload/
+    # before uploading; with `protected_hardlinks=1` (Linux default)
+    # the linker must own the source file. The block files are written
+    # by prometheus-2 as nobody:nobody, so the sidecar must match.
+    # Same root cause as sidecar-1's fix in PR #42, just surfaced as a
+    # different error message ("hard link: operation not permitted")
+    # because the NAS bind-mount is 0777 — the kernel let us past the
+    # mkdir but blocked the hardlink.
+    user: "65534:65534"
     networks:
       home-net:
         ipv4_address: 192.168.4.239


### PR DESCRIPTION
## Summary

Companion follow-up to #43. After flipping sidecar-2's mount `:ro` → `:rw`, the shipper hit a deeper issue: hardlinks into the upload-staging dir fail with `operation not permitted` because of Linux's `protected_hardlinks=1` default — the linker has to own the source file.

```text
err="upload <ULID>: hard link block: hard link file chunks/000001:
     link /prometheus/<ULID>/chunks/000001
          /prometheus/thanos/upload/<ULID>/chunks/000001:
     operation not permitted" uploaded=0
```

Block files on the NAS are written by `prometheus-2` as `nobody:nobody` (uid 65534) but the sidecar runs as the default thanos uid 1001 — same root cause as #42 (sidecar-1), just surfaced as a different error message because the NAS bind-mount path is 0777, so the kernel let us past the `mkdir` but blocked the hardlink.

Fix: same one-line `user: "65534:65534"` override as #42.

## Test plan

- [ ] `terraform apply` shows `~ portainer_stack.prometheus_2`, 0 add, 0 destroy
- [ ] `./scripts/portainer-redeploy.py prometheus-2` cleanly recreates sidecar-2
- [ ] sidecar-2 logs no longer show `operation not permitted`; first `uploaded=N` (N>0) appears within 1 minute
- [ ] `mc ls local/thanos/` grows beyond the 143 blocks sidecar-1 already shipped, with `meta.json` showing `replica: B` on the new ones