### PR TITLE
feat(monitoring): stand up thanos-compactor + thanos-ruler on ds-2

### DIFF
--- a/terraform/portainer/locals.tf
+++ b/terraform/portainer/locals.tf
@@ -117,7 +117,7 @@ locals {
           - target_label: __address__
             replacement: 192.168.59.29:9116
 
-      # ── Thanos self-scrape (sidecar-1+2, query, store-gw) ───────────
+      # ── Thanos self-scrape (sidecar-1+2, query, store-gw, compact, rule) ─
       - job_name: thanos
         static_configs:
           - targets: [192.168.59.20:10902]
@@ -128,6 +128,10 @@ locals {
             labels: { instance: thanos-store-gw }
           - targets: [192.168.59.26:10902]
             labels: { instance: thanos-query }
+          - targets: [192.168.59.51:10902]
+            labels: { instance: thanos-compact }
+          - targets: [192.168.59.52:10902]
+            labels: { instance: thanos-rule }
 
       # ── Alertmanager HA pair self-scrape ────────────────────────────
       # Both AMs are alert *receivers* (see alerting block above) but

--- a/terraform/portainer/stacks.tf
+++ b/terraform/portainer/stacks.tf
@@ -553,6 +553,46 @@ resource "portainer_stack" "node_exporter_dm" {
   stack_file_content = file("${path.module}/stacks/node-exporter-dm.yml")
 }
 
+# thanos-compactor on ds-2 (Phase 1 batch plane).
+# Single instance — TWO compactors against the same bucket WILL corrupt
+# blocks per upstream docs. Owns block compaction, downsampling
+# (raw->5m->1h), retention enforcement, and replica-label dedup.
+# Reads/writes via objstore-ds2 → minio-2 (loopback-fast on ds-2).
+resource "portainer_stack" "thanos_compact" {
+  name            = "thanos-compact"
+  endpoint_id     = var.ds2_endpoint_id
+  deployment_type = "standalone"
+  method          = "string"
+
+  stack_file_content = templatefile("${path.module}/stacks/thanos-compact.yml.tftpl", {
+    objstore_config = templatefile("${path.module}/stacks/objstore-ds2.yml.tftpl", {
+      access_key = data.vault_kv_secret_v2.thanos.data["access_key"]
+      secret_key = data.vault_kv_secret_v2.thanos.data["secret_key"]
+    })
+  })
+}
+
+# thanos-ruler on ds-2 (Phase 1 batch plane).
+# Single instance per design — long-window alerts that require
+# >15d history (capacity trends, cert-expiry beyond 30d, SLO burn-rate)
+# evaluate over Thanos data via the Querier. Short-window alerts stay
+# native to both prometheus replicas (no SPOF).
+# Initial deploy ships with an empty rules placeholder; real rules in a
+# follow-up PR.
+resource "portainer_stack" "thanos_rule" {
+  name            = "thanos-rule"
+  endpoint_id     = var.ds2_endpoint_id
+  deployment_type = "standalone"
+  method          = "string"
+
+  stack_file_content = templatefile("${path.module}/stacks/thanos-rule.yml.tftpl", {
+    objstore_config = templatefile("${path.module}/stacks/objstore-ds2.yml.tftpl", {
+      access_key = data.vault_kv_secret_v2.thanos.data["access_key"]
+      secret_key = data.vault_kv_secret_v2.thanos.data["secret_key"]
+    })
+  })
+}
+
 # node-exporter on ds-2 (host network mode).
 resource "portainer_stack" "node_exporter_ds2" {
   name            = "node-exporter-ds2"

--- a/terraform/portainer/stacks/objstore-ds2.yml.tftpl
+++ b/terraform/portainer/stacks/objstore-ds2.yml.tftpl
@@ -1,0 +1,16 @@
+# Thanos object-store config for the ds-2 plane (compactor + ruler).
+# Both processes are on docker-servers-net and reach MinIO via its
+# internal LAN address. Prefers minio-2 (192.168.59.37:9000) because
+# minio-2 is colocated on ds-2 — saves cross-host bandwidth during
+# downsampling. Site replication keeps minio-1 in sync.
+#
+# Distinct from objstore-ds1 (ds-1 plane → minio-1) and objstore-nas
+# (NAS plane → public TLS LB).
+type: S3
+config:
+  bucket: thanos
+  endpoint: 192.168.59.37:9000
+  access_key: ${access_key}
+  secret_key: ${secret_key}
+  insecure: true
+  signature_version2: false

--- a/terraform/portainer/stacks/thanos-compact.yml.tftpl
+++ b/terraform/portainer/stacks/thanos-compact.yml.tftpl
@@ -1,0 +1,83 @@
+name: thanos-compact
+
+# thanos-compactor — single instance on ds-2 (TWO compactors against the
+# same bucket WILL corrupt blocks, per upstream docs). Owns:
+#   - block compaction (merge 2h prom-emitted blocks into bigger units)
+#   - downsampling (raw → 5m → 1h resolution tiers)
+#   - retention enforcement (delete blocks past retention threshold)
+#   - replica-label dedup (merge replica=A and replica=B into one
+#     time-series before downsampling — saves storage)
+#
+# Why ds-2: colocated with minio-2 on the same host, so reads during
+# downsampling go through the local TCP loopback path. Also keeps the
+# heaviest batch job off the dockermaster control plane.
+#
+# Local data dir is a working scratch area for in-flight compactions —
+# Thanos writes uncompressed intermediate blocks here; sized for the
+# largest block expected (~5GB raw 2h * 2 replicas = ~10GB peak,
+# rounded up).
+
+networks:
+  servers-net:
+    name: docker-servers-net
+    external: true
+
+volumes:
+  thanos_compact_data:
+    name: thanos_compact_data
+
+configs:
+  objstore_yml:
+    content: |
+      ${indent(6, objstore_config)}
+
+services:
+  thanos-compact:
+    image: quay.io/thanos/thanos:v0.41.0
+    hostname: thanos-compact
+    # Run as root so the named-volume mkdir works on first boot
+    # (docker creates named volumes root-owned). Same pattern as
+    # thanos-store-gw.
+    user: "0:0"
+    networks:
+      servers-net:
+        # IP picked from 192.168.59.0/26 free pool
+        ipv4_address: 192.168.59.51
+    command:
+      - compact
+      - --wait
+      - --data-dir=/var/thanos/compact
+      - --objstore.config-file=/etc/thanos/objstore.yml
+      - --retention.resolution-raw=90d
+      - --retention.resolution-5m=365d
+      - --retention.resolution-1h=730d
+      - --deduplication.replica-label=replica
+      # Keep compactor concurrency conservative — ds-2 is shared with
+      # minio-2 + future ruler. Bump if compaction falls behind.
+      - --compact.concurrency=1
+      - --downsample.concurrency=1
+      - --http-address=0.0.0.0:10902
+      - --log.level=info
+    volumes:
+      - thanos_compact_data:/var/thanos/compact
+    configs:
+      - source: objstore_yml
+        target: /etc/thanos/objstore.yml
+        mode: 0644
+    expose:
+      - "10902"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:10902/-/healthy"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      # Compactor's first cycle can take a while if it has to scan the
+      # whole bucket — give it 5 minutes before the healthcheck panics.
+      start_period: 300s
+    labels:
+      loki.logging: "true"
+      com.centurylinklabs.watchtower.enable: "false"
+      com.docker.stack: "thanos-compact"
+      com.docker.service: "thanos-compact"
+      portainer.autodeploy: "false"

--- a/terraform/portainer/stacks/thanos-query.yml
+++ b/terraform/portainer/stacks/thanos-query.yml
@@ -28,9 +28,10 @@ services:
       - --grpc-address=0.0.0.0:10901
       - --query.replica-label=replica
       - --query.auto-downsampling
-      - --endpoint=192.168.59.20:10901
-      - --endpoint=192.168.59.21:10901
-      - --endpoint=192.168.4.239:10901
+      - --endpoint=192.168.59.20:10901   # thanos-sidecar-1 (ds-1, replica A)
+      - --endpoint=192.168.59.21:10901   # thanos-store-gw (ds-1, historical blocks)
+      - --endpoint=192.168.4.239:10901   # thanos-sidecar-2 (NAS, replica B)
+      - --endpoint=192.168.59.52:10901   # thanos-rule (ds-2, recorded rule blocks)
       - --log.level=info
     expose:
       - "10901"

--- a/terraform/portainer/stacks/thanos-rule.yml.tftpl
+++ b/terraform/portainer/stacks/thanos-rule.yml.tftpl
@@ -1,0 +1,98 @@
+name: thanos-rule
+
+# thanos-ruler — single instance on ds-2 (per design — no HA pair).
+# Evaluates alert rules over Thanos data via the Querier, so rules can
+# span time windows longer than any local Prometheus retention
+# (e.g., "disk growth > 5 GB/month for the last 6 months").
+#
+# Rule placement policy:
+#   - rules/prometheus/*.yml — short-window high-urgency alerts; loaded
+#     by BOTH prometheus-1 and prometheus-2 (no SPOF; alertmanagers
+#     dedupe).
+#   - rules/thanos/*.yml — long-window or cross-replica alerts; loaded
+#     by Ruler only. If ds-2 is down, these rules don't evaluate.
+#
+# Alertmanager wiring: --alertmanagers.url is repeated for both AM
+# replicas; the AM cluster gossip dedupes the alerts.
+#
+# Ruler also writes its own evaluation result blocks back to the
+# objstore (--objstore.config-file) so the Querier can read recorded
+# rules from history.
+
+networks:
+  servers-net:
+    name: docker-servers-net
+    external: true
+
+volumes:
+  thanos_rule_data:
+    name: thanos_rule_data
+
+configs:
+  objstore_yml:
+    content: |
+      ${indent(6, objstore_config)}
+  # Phase 1 placeholder rules file. Real long-window rules go here in a
+  # follow-up PR (capacity trends, cert-expiry beyond 30d, SLO burn
+  # rates). Kept as an empty `groups:` so the ruler boots cleanly.
+  thanos_rules:
+    content: |
+      groups: []
+
+services:
+  thanos-rule:
+    image: quay.io/thanos/thanos:v0.41.0
+    hostname: thanos-rule
+    user: "0:0"
+    networks:
+      servers-net:
+        # IP picked from 192.168.59.0/26 free pool
+        ipv4_address: 192.168.59.52
+    command:
+      - rule
+      - --data-dir=/var/thanos/rule
+      - --objstore.config-file=/etc/thanos/objstore.yml
+      - --rule-file=/etc/thanos/rules/*.yml
+      # Single ruler instance, but still set a replica label so the AM
+      # cluster's dedup hash includes it (defensive — supports a future
+      # second ruler without rule churn).
+      - --label=replica="ruler-1"
+      - --label=cluster="homelab"
+      - --label=region="local"
+      # Query layer to evaluate rules against — go directly to thanos-query
+      # on dockermaster (HA fan-out across both prometheus replicas + the
+      # store gateway).
+      - --query=thanos-query.servers-net:10902
+      # Both alertmanagers; gossip handles dedup.
+      - --alertmanagers.url=http://192.168.59.27:9093
+      - --alertmanagers.url=http://192.168.4.238:9093
+      # Eval cadence — 1 minute is plenty for long-window rules.
+      - --eval-interval=1m
+      - --http-address=0.0.0.0:10902
+      - --grpc-address=0.0.0.0:10901
+      - --log.level=info
+    volumes:
+      - thanos_rule_data:/var/thanos/rule
+    configs:
+      - source: objstore_yml
+        target: /etc/thanos/objstore.yml
+        mode: 0644
+      - source: thanos_rules
+        target: /etc/thanos/rules/placeholder.yml
+        mode: 0644
+    expose:
+      - "10901"
+      - "10902"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:10902/-/healthy"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    labels:
+      loki.logging: "true"
+      com.centurylinklabs.watchtower.enable: "false"
+      com.docker.stack: "thanos-rule"
+      com.docker.service: "thanos-rule"
+      portainer.autodeploy: "false"


### PR DESCRIPTION
## Summary

Phase 1 batch plane goes live now that sidecar shipping is fixed (PRs #42 + #44). Without these two, the Thanos retention plan can't execute and long-window alerts have no evaluator.

## What's added

| Stack | Host | IP | Image |
|---|---|---|---|
| `thanos-compact` | ds-2 | 192.168.59.51 | `quay.io/thanos/thanos:v0.41.0` |
| `thanos-rule` | ds-2 | 192.168.59.52 | `quay.io/thanos/thanos:v0.41.0` |

### Compactor (`stacks/thanos-compact.yml.tftpl`)

Single instance per upstream guidance — TWO compactors against the same bucket WILL corrupt blocks. Owns:

- Block compaction (merge 2h prom-emitted blocks into bigger units)
- Downsampling (raw → 5m → 1h tiers)
- Retention enforcement: raw 90d / 5m 365d / 1h 730d (per design doc)
- Replica-label dedup (merges `replica=A` and `replica=B` into one series before downsampling)

Conservative `--compact.concurrency=1` / `--downsample.concurrency=1` so it doesn't starve minio-2 sharing the host.

### Ruler (`stacks/thanos-rule.yml.tftpl`)

Single instance per design — long-window or cross-replica alerts that require >15d history evaluate over Thanos data via the Querier. Short-window high-urgency alerts stay native to both prometheus replicas (no SPOF).

Ships with an empty `groups: []` placeholder; real long-window rules (capacity trends, cert-expiry beyond 30d, SLO burn-rate) go in a follow-up PR. Sends alerts to BOTH alertmanagers; gossip cluster dedupes.

### Supporting changes

- `stacks/objstore-ds2.yml.tftpl` — Thanos S3 config pointing at minio-2 (192.168.59.37:9000), the local-loopback path on ds-2. Site replication keeps minio-1 in sync.
- `stacks/thanos-query.yml` — adds `--endpoint=192.168.59.52:10901` so the Querier can serve recorded rule blocks.
- `locals.tf` — adds `thanos-compact` and `thanos-rule` to the `thanos` scrape job (2 new prometheus targets).

## Plan

```text
$ terraform plan
  # portainer_stack.prometheus will be updated in-place
  # portainer_stack.thanos_compact will be created
  # portainer_stack.thanos_query will be updated in-place
  # portainer_stack.thanos_rule will be created
Plan: 2 to add, 2 to change, 0 to destroy.
```

## Deploy procedure

Per memory `feedback_portainer_stack_redeploy.md` — `terraform apply` updates Portainer's stored definition but doesn't recreate running containers when only the compose body changes. New stacks always create fresh, but the in-place updates need a redeploy:

```bash
cd terraform/portainer && terraform apply
./scripts/portainer-redeploy.py prometheus thanos-query
```

## Test plan

- [ ] `terraform apply` succeeds — 2 created, 2 updated.
- [ ] `docker ps` on ds-2 shows `thanos-compact` and `thanos-rule` UP.
- [ ] Compactor first cycle (allow 5+ minutes — `start_period: 300s`); logs emit `compactor: compaction iteration done`.
- [ ] Ruler ready: `curl http://192.168.59.52:10902/-/ready` returns 200.
- [ ] `thanos-query`'s `/api/v1/stores` lists `thanos-rule` (sidecar-1, sidecar-2, store-gw, rule).
- [ ] Prometheus `thanos` job target count goes from 4 UP to **6 UP**.
- [ ] After a compaction cycle: bucket has compacted block ULIDs alongside raw 2h ones. Visible via `mc ls local/thanos | wc -l` decreasing as blocks get merged.

## Out of scope

- Real `rules/thanos/*.yml` content — placeholder ships with `groups: []`. Long-window rules in a separate PR.
- Sidecar-2 orphan dir cleanup on NAS (host-level chown blocked by sandbox; tracked separately).