### PR TITLE
feat(monitoring): postgres_exporter for keycloak-db pair + postgres-rundeck

### DIFF
--- a/terraform/portainer/locals.tf
+++ b/terraform/portainer/locals.tf
@@ -390,6 +390,20 @@ locals {
             labels:
               instance: pihole-3
 
+      # ── postgres_exporter — keycloak-db pair + postgres-rundeck ─────
+      # Per-DB exporters give each repmgr node its own pg_stat_replication
+      # view perspective (memory: feedback_container_health_vs_process —
+      # captured the case where keycloak-db-0 ran 5d "healthy" with
+      # zombie processes; per-node visibility prevents that).
+      - job_name: postgres
+        static_configs:
+          - targets: ['192.168.59.55:9187']
+            labels: { instance: keycloak-db-0 }
+          - targets: ['192.168.59.56:9187']
+            labels: { instance: keycloak-db-1 }
+          - targets: ['192.168.59.57:9187']
+            labels: { instance: postgres-rundeck }
+
       # ── Phase 3f: Rundeck (no scrape — see note) ────────────────────
       # Rundeck OSS 5.x exposes Dropwizard metrics at /metrics/metrics
       # but gates that endpoint behind session-cookie auth — it does
@@ -703,6 +717,17 @@ locals {
           - targets: ['192.168.4.240:9666']
             labels:
               instance: pihole-3
+
+      # ── postgres_exporter — keycloak-db pair + postgres-rundeck ─────
+      # Mirror of replica-A job. See replica-A comment for context.
+      - job_name: postgres
+        static_configs:
+          - targets: ['192.168.59.55:9187']
+            labels: { instance: keycloak-db-0 }
+          - targets: ['192.168.59.56:9187']
+            labels: { instance: keycloak-db-1 }
+          - targets: ['192.168.59.57:9187']
+            labels: { instance: postgres-rundeck }
 
       # ── Phase 3f: Rundeck (no scrape — see replica-A note) ──────────
 

--- a/terraform/portainer/stacks.tf
+++ b/terraform/portainer/stacks.tf
@@ -593,6 +593,45 @@ resource "portainer_stack" "thanos_rule" {
   })
 }
 
+# postgres_exporter for keycloak-db-0 (Bitnami repmgr primary on dockermaster).
+# DATA_SOURCE_NAME uses the postgres superuser bootstrap creds from Vault.
+resource "portainer_stack" "postgres_exporter_keycloak_db_0" {
+  name            = "postgres-exporter-keycloak-db-0"
+  endpoint_id     = var.endpoint_id
+  deployment_type = "standalone"
+  method          = "string"
+
+  stack_file_content = templatefile("${path.module}/stacks/postgres-exporter-keycloak-db-0.yml.tftpl", {
+    data_source_name = "postgresql://postgres:${data.vault_kv_secret_v2.keycloak.data["postgres_root_password"]}@192.168.59.44:5432/postgres?sslmode=disable"
+  })
+}
+
+# postgres_exporter for keycloak-db-1 (Bitnami repmgr standby on ds-1).
+resource "portainer_stack" "postgres_exporter_keycloak_db_1" {
+  name            = "postgres-exporter-keycloak-db-1"
+  endpoint_id     = var.ds1_endpoint_id
+  deployment_type = "standalone"
+  method          = "string"
+
+  stack_file_content = templatefile("${path.module}/stacks/postgres-exporter-keycloak-db-1.yml.tftpl", {
+    data_source_name = "postgresql://postgres:${data.vault_kv_secret_v2.keycloak.data["postgres_root_password"]}@192.168.59.54:5432/postgres?sslmode=disable"
+  })
+}
+
+# postgres_exporter for postgres-rundeck (vanilla postgres:17 on ds-1).
+# Standalone postgres so no replication-state metrics; main interest is
+# connection-pool saturation + query metrics.
+resource "portainer_stack" "postgres_exporter_rundeck" {
+  name            = "postgres-exporter-rundeck"
+  endpoint_id     = var.ds1_endpoint_id
+  deployment_type = "standalone"
+  method          = "string"
+
+  stack_file_content = templatefile("${path.module}/stacks/postgres-exporter-rundeck.yml.tftpl", {
+    data_source_name = "postgresql://rundeck:${data.vault_kv_secret_v2.rundeck.data["db_password"]}@192.168.59.23:5432/rundeck?sslmode=disable"
+  })
+}
+
 # node-exporter on ds-2 (host network mode).
 resource "portainer_stack" "node_exporter_ds2" {
   name            = "node-exporter-ds2"

--- a/terraform/portainer/stacks/postgres-exporter-keycloak-db-0.yml.tftpl
+++ b/terraform/portainer/stacks/postgres-exporter-keycloak-db-0.yml.tftpl
@@ -1,0 +1,48 @@
+name: postgres-exporter-keycloak-db-0
+
+# postgres_exporter for keycloak-db-0 (Bitnami postgresql-repmgr 17.6.0).
+# Colocated on dockermaster, scrapes postgres on 192.168.59.44:5432.
+#
+# Why per-DB instead of multi-target: each exporter has its own
+# `pg_stat_replication` view perspective, which is critical for
+# repmgr cluster health monitoring (memory:
+# feedback_container_health_vs_process.md captured the case where
+# keycloak-db-0 ran 5 days "healthy" with zombie processes — separate
+# exporter per node makes such states visible).
+#
+# Scrapes the `postgres` superuser (DATA_SOURCE_NAME from Vault). A
+# dedicated `pg_monitor` role would be cleaner long-term but requires
+# bootstrap SQL inside the DB; punted for now.
+
+networks:
+  servers-net:
+    name: docker-servers-net
+    external: true
+
+services:
+  postgres-exporter:
+    image: quay.io/prometheuscommunity/postgres-exporter:v0.19.1
+    hostname: postgres-exporter-keycloak-db-0
+    networks:
+      servers-net:
+        # IP picked from 192.168.59.0/26 free pool
+        ipv4_address: 192.168.59.55
+    environment:
+      DATA_SOURCE_NAME: ${data_source_name}
+      PG_EXPORTER_AUTO_DISCOVER_DATABASES: "true"
+      PG_EXPORTER_EXCLUDE_DATABASES: "template0,template1"
+    expose:
+      - "9187"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:9187/metrics"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    labels:
+      loki.logging: "true"
+      com.centurylinklabs.watchtower.enable: "false"
+      com.docker.stack: "postgres-exporter-keycloak-db-0"
+      com.docker.service: "postgres-exporter"
+      portainer.autodeploy: "false"

--- a/terraform/portainer/stacks/postgres-exporter-keycloak-db-1.yml.tftpl
+++ b/terraform/portainer/stacks/postgres-exporter-keycloak-db-1.yml.tftpl
@@ -1,0 +1,39 @@
+name: postgres-exporter-keycloak-db-1
+
+# postgres_exporter for keycloak-db-1 (Bitnami postgresql-repmgr 17.6.0).
+# Colocated on ds-1, scrapes postgres on 192.168.59.54:5432.
+# Mirror of postgres-exporter-keycloak-db-0; see that stack file for
+# rationale.
+
+networks:
+  servers-net:
+    name: docker-servers-net
+    external: true
+
+services:
+  postgres-exporter:
+    image: quay.io/prometheuscommunity/postgres-exporter:v0.19.1
+    hostname: postgres-exporter-keycloak-db-1
+    networks:
+      servers-net:
+        # IP picked from 192.168.59.0/26 free pool
+        ipv4_address: 192.168.59.56
+    environment:
+      DATA_SOURCE_NAME: ${data_source_name}
+      PG_EXPORTER_AUTO_DISCOVER_DATABASES: "true"
+      PG_EXPORTER_EXCLUDE_DATABASES: "template0,template1"
+    expose:
+      - "9187"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:9187/metrics"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    labels:
+      loki.logging: "true"
+      com.centurylinklabs.watchtower.enable: "false"
+      com.docker.stack: "postgres-exporter-keycloak-db-1"
+      com.docker.service: "postgres-exporter"
+      portainer.autodeploy: "false"

--- a/terraform/portainer/stacks/postgres-exporter-rundeck.yml.tftpl
+++ b/terraform/portainer/stacks/postgres-exporter-rundeck.yml.tftpl
@@ -1,0 +1,40 @@
+name: postgres-exporter-rundeck
+
+# postgres_exporter for postgres-rundeck (vanilla postgres:17).
+# Colocated on ds-1 with the rundeck stack, scrapes 192.168.59.23:5432.
+# Standalone postgres (not repmgr) so no replication-state metrics;
+# main interest is connection-pool saturation, query duration, table
+# bloat, and basic up/down.
+
+networks:
+  servers-net:
+    name: docker-servers-net
+    external: true
+
+services:
+  postgres-exporter:
+    image: quay.io/prometheuscommunity/postgres-exporter:v0.19.1
+    hostname: postgres-exporter-rundeck
+    networks:
+      servers-net:
+        # IP picked from 192.168.59.0/26 free pool
+        ipv4_address: 192.168.59.57
+    environment:
+      DATA_SOURCE_NAME: ${data_source_name}
+      PG_EXPORTER_AUTO_DISCOVER_DATABASES: "true"
+      PG_EXPORTER_EXCLUDE_DATABASES: "template0,template1"
+    expose:
+      - "9187"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:9187/metrics"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    labels:
+      loki.logging: "true"
+      com.centurylinklabs.watchtower.enable: "false"
+      com.docker.stack: "postgres-exporter-rundeck"
+      com.docker.service: "postgres-exporter"
+      portainer.autodeploy: "false"


### PR DESCRIPTION
## Summary

Phase D coverage gap closure. 3 new postgres_exporter stacks, one per database, colocated with the target on its host.

| Exporter | DB target | Host | Exporter IP |
|---|---|---|---|
| `postgres-exporter-keycloak-db-0` | 192.168.59.44 (Bitnami repmgr primary) | dockermaster | 192.168.59.55 |
| `postgres-exporter-keycloak-db-1` | 192.168.59.54 (Bitnami repmgr standby) | ds-1 | 192.168.59.56 |
| `postgres-exporter-rundeck` | 192.168.59.23 (postgres:17) | ds-1 | 192.168.59.57 |

## Why per-DB (not multi-target)

Each repmgr node has its own `pg_stat_replication` view perspective. Memory `feedback_container_health_vs_process.md` captured the exact failure mode: keycloak-db-0 ran 5 days "healthy" with zombie postgres processes. Per-node visibility catches that via `pg_stat_replication` going stale on the standby + `pg_is_in_recovery` flapping on the primary.

## Plan

```text
$ terraform plan
  # portainer_stack.postgres_exporter_keycloak_db_0 will be created
  # portainer_stack.postgres_exporter_keycloak_db_1 will be created
  # portainer_stack.postgres_exporter_rundeck will be created
  # portainer_stack.prometheus will be updated in-place
  # portainer_stack.prometheus_2 will be updated in-place
Plan: 3 to add, 2 to change, 0 to destroy.
```

## Deploy

```bash
cd terraform/portainer && terraform apply
./scripts/portainer-redeploy.py prometheus prometheus-2
```

## Test plan

- [ ] All 3 exporter containers come up healthy on their respective hosts.
- [ ] `curl http://192.168.59.55:9187/metrics` returns `pg_up 1`.
- [ ] Prometheus `postgres` job: 3/3 UP after redeploy.
- [ ] Spot-check series exist: `pg_up{instance="keycloak-db-0"}`, `pg_stat_replication_lag_bytes{instance="keycloak-db-0"}`.
- [ ] On ds-1 (standby): `pg_is_in_recovery{instance="keycloak-db-1"} == 1`.
- [ ] No regression on the existing 66 prom targets.