### PR TITLE
feat(monitoring): nginx-prometheus-exporter sidecar to rproxy

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -616,10 +616,15 @@ jobs:
           done
 
           if [ -n "$MISSING_INVENTORY" ]; then
-            echo "missing_inventory=$MISSING_INVENTORY" >> $GITHUB_OUTPUT
-            echo "inventory_complete=false" >> $GITHUB_OUTPUT
+            # Same multi-line guard as outdated_reason below.
+            {
+              echo 'missing_inventory<<MISSING_INVENTORY_EOF'
+              echo "$MISSING_INVENTORY"
+              echo 'MISSING_INVENTORY_EOF'
+            } >> "$GITHUB_OUTPUT"
+            echo "inventory_complete=false" >> "$GITHUB_OUTPUT"
           else
-            echo "inventory_complete=true" >> $GITHUB_OUTPUT
+            echo "inventory_complete=true" >> "$GITHUB_OUTPUT"
           fi
 
           # Check if documentation is up to date (basic check)
@@ -634,13 +639,20 @@ jobs:
 
           if [ -n "$CONFIG_CHANGES" ] && [ -z "$DOC_CHANGES" ]; then
             echo "⚠️ Configuration files changed but no documentation updates found"
-            echo "docs_may_need_update=true" >> $GITHUB_OUTPUT
+            echo "docs_may_need_update=true" >> "$GITHUB_OUTPUT"
             DOCS_OUTDATED="Configuration files changed: $CONFIG_CHANGES"
           else
-            echo "docs_may_need_update=false" >> $GITHUB_OUTPUT
+            echo "docs_may_need_update=false" >> "$GITHUB_OUTPUT"
           fi
 
-          echo "outdated_reason=$DOCS_OUTDATED" >> $GITHUB_OUTPUT
+          # `outdated_reason` may contain multiple newlines (one path per
+          # line) — bare `key=value` writes break GITHUB_OUTPUT parsing.
+          # Use the heredoc form for any multi-line value.
+          {
+            echo 'outdated_reason<<OUTDATED_REASON_EOF'
+            echo "$DOCS_OUTDATED"
+            echo 'OUTDATED_REASON_EOF'
+          } >> "$GITHUB_OUTPUT"
 
       - name: Generate documentation report
         if: always()

--- a/dockermaster/docker/compose/nginx-rproxy/conf/nginx.conf
+++ b/dockermaster/docker/compose/nginx-rproxy/conf/nginx.conf
@@ -36,6 +36,25 @@ http {
     otel_trace on;
     otel_service_name "rproxy-service"; # Set your service name
 
+    # nginx_status server — stub_status endpoint scraped by the
+    # nginx-prometheus-exporter sidecar over the rproxy bridge network.
+    # Listens on :8080 INSIDE the container only — not in the `expose:`
+    # or `ports:` lists in the Compose stack, so it never reaches the
+    # macvlan/host. Access is gated by network ACL: only the rproxy
+    # bridge subnet (172.20.0.0/24 — Docker auto-assigns) and 127.0.0.1
+    # are allowed.
+    server {
+        listen 8080;
+        server_name _;
+        access_log off;
+        location /nginx_status {
+            stub_status on;
+            allow 127.0.0.0/8;
+            allow 172.16.0.0/12;   # Docker bridge ranges
+            deny all;
+        }
+    }
+
     # This line includes any additional server blocks you define in the conf.d directory
     include /etc/nginx/vhost.d/*.conf;
 }

--- a/terraform/portainer/locals.tf
+++ b/terraform/portainer/locals.tf
@@ -404,6 +404,13 @@ locals {
           - targets: ['192.168.59.57:9187']
             labels: { instance: postgres-rundeck }
 
+      # ── nginx-prometheus-exporter — rproxy throughput / connection
+      # saturation. Scrapes nginx stub_status via shared bridge network.
+      - job_name: nginx
+        static_configs:
+          - targets: ['192.168.59.58:9113']
+            labels: { instance: nginx-rproxy }
+
       # ── Phase 3f: Rundeck (no scrape — see note) ────────────────────
       # Rundeck OSS 5.x exposes Dropwizard metrics at /metrics/metrics
       # but gates that endpoint behind session-cookie auth — it does
@@ -728,6 +735,12 @@ locals {
             labels: { instance: keycloak-db-1 }
           - targets: ['192.168.59.57:9187']
             labels: { instance: postgres-rundeck }
+
+      # ── nginx-prometheus-exporter — mirror of replica-A.
+      - job_name: nginx
+        static_configs:
+          - targets: ['192.168.59.58:9113']
+            labels: { instance: nginx-rproxy }
 
       # ── Phase 3f: Rundeck (no scrape — see replica-A note) ──────────
 

--- a/terraform/portainer/stacks.tf
+++ b/terraform/portainer/stacks.tf
@@ -632,6 +632,18 @@ resource "portainer_stack" "postgres_exporter_rundeck" {
   })
 }
 
+# nginx-prometheus-exporter on dockermaster — sidecar to nginx-rproxy.
+# Scrapes the local stub_status server (gated to Docker bridge ranges,
+# not in `expose:`) over the shared `rproxy` bridge network.
+resource "portainer_stack" "nginx_exporter" {
+  name            = "nginx-exporter"
+  endpoint_id     = var.endpoint_id
+  deployment_type = "standalone"
+  method          = "string"
+
+  stack_file_content = file("${path.module}/stacks/nginx-exporter.yml")
+}
+
 # node-exporter on ds-2 (host network mode).
 resource "portainer_stack" "node_exporter_ds2" {
   name            = "node-exporter-ds2"

--- a/terraform/portainer/stacks/nginx-exporter.yml
+++ b/terraform/portainer/stacks/nginx-exporter.yml
@@ -1,0 +1,49 @@
+name: nginx-exporter
+
+# nginx-prometheus-exporter on dockermaster, scraping the rproxy
+# stub_status endpoint over the shared `rproxy` bridge network at
+# http://rproxy:8080/nginx_status. The stub_status server inside
+# nginx is gated by network ACL (allow 127.0.0.0/8 + 172.16.0.0/12)
+# and is not in nginx-rproxy's `expose:` list — it only reaches
+# containers on the same bridge.
+#
+# Phase D coverage gap closure (per docs/monitoring-coverage-gap-2026-05-07.md).
+# Metrics: nginx_connections_{accepted,handled,active,reading,writing,waiting},
+# nginx_http_requests_total. Useful for: rproxy throughput, connection
+# saturation, request rate spikes, slow-handling counts.
+
+networks:
+  rproxy:
+    name: rproxy
+    external: true
+  servers-net:
+    name: docker-servers-net
+    external: true
+
+services:
+  nginx-exporter:
+    image: nginx/nginx-prometheus-exporter:1.5.1
+    hostname: nginx-exporter
+    networks:
+      servers-net:
+        # IP picked from 192.168.59.0/26 free pool
+        ipv4_address: 192.168.59.58
+      rproxy:
+    command:
+      - --nginx.scrape-uri=http://rproxy:8080/nginx_status
+      - --web.listen-address=:9113
+    expose:
+      - "9113"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:9113/metrics"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    labels:
+      loki.logging: "true"
+      com.centurylinklabs.watchtower.enable: "false"
+      com.docker.stack: "nginx-exporter"
+      com.docker.service: "nginx-exporter"
+      portainer.autodeploy: "false"


### PR DESCRIPTION
## Summary

Phase D coverage gap closure for the nginx-rproxy throughput / connection-saturation observability gap. Adds a sidecar exporter on the rproxy bridge network and a new `nginx` scrape job on both prom replicas.

## Changes

| File | What |
|---|---|
| `dockermaster/docker/compose/nginx-rproxy/conf/nginx.conf` | New internal `stub_status` server on `:8080`, ACL-gated to `127.0.0.0/8` + `172.16.0.0/12` (Docker bridge ranges). Not in `expose:`. |
| `terraform/portainer/stacks/nginx-exporter.yml` | Sidecar exporter at 192.168.59.58:9113 on the rproxy bridge. Image `nginx/nginx-prometheus-exporter:1.5.1` per VERSIONS.md. |
| `terraform/portainer/stacks.tf` | New `portainer_stack.nginx_exporter` on dockermaster. |
| `terraform/portainer/locals.tf` | `nginx` scrape job on both replicas. |

## Plan

```text
$ terraform plan
  # portainer_stack.nginx_exporter will be created
  # portainer_stack.prometheus will be updated in-place
  # portainer_stack.prometheus_2 will be updated in-place
  # portainer_stack.reverse_proxy will be updated in-place
  # portainer_stack.reverse_proxy_2 will be updated in-place
  # portainer_stack.reverse_proxy_3 will be updated in-place
Plan: 1 to add, 5 to change, 0 to destroy.
```

The 3 reverse-proxy stacks pick up the nginx.conf change via their shared `vhost_*` configs block.

## ⚠️ Deploy note: brief rproxy blip

Redeploying the 3 reverse-proxy stacks causes a brief outage on every `*.d.lcamaral.com` and `*.cf.lcamaral.com` endpoint while each stack restarts (a few seconds each, sequential). Acceptable cost for the observability, but worth knowing if running during peak traffic.

```bash
cd terraform/portainer && terraform apply
./scripts/portainer-redeploy.py prometheus prometheus-2 \
  reverse-proxy reverse-proxy-2 reverse-proxy-3
```

## Test plan

- [ ] After apply: `nginx-exporter-nginx-exporter-1` healthy on dockermaster.
- [ ] `curl http://192.168.59.58:9113/metrics | grep nginx_up` returns `1`.
- [ ] Prometheus `nginx` job 1/1 UP after redeploy.
- [ ] `nginx_connections_active`, `nginx_http_requests_total` series present.
- [ ] All 3 reverse-proxy containers come back UP after redeploy.
- [ ] Spot-check `https://vault.d.lcamaral.com/v1/sys/health` still returns 200.