### PR TITLE
fix(monitoring): allow macvlan range in nginx_status ACL

### DIFF
--- a/dockermaster/docker/compose/nginx-rproxy/conf/nginx.conf
+++ b/dockermaster/docker/compose/nginx-rproxy/conf/nginx.conf
@@ -51,6 +51,7 @@ http {
             stub_status on;
             allow 127.0.0.0/8;
             allow 172.16.0.0/12;   # Docker bridge ranges
+            allow 192.168.59.0/24; # docker-servers-net macvlan
             deny all;
         }
     }


### PR DESCRIPTION
Quick follow-up to #47. The stub_status ACL was set to `127.0.0.0/8` + `172.16.0.0/12` expecting bridge-internal traffic, but in practice Docker DNS resolved `rproxy` to its macvlan IP for nginx-exporter (multi-network container) — request went out via macvlan, source IP `192.168.59.58`, denied with 403.

```text
# nginx-exporter logs:
"error getting stats" error="expected 200 response, got 403"
```

Add `192.168.59.0/24` to allow list. Port stays out of rproxy `expose:`, so only docker-servers-net peers reach it — same blast radius as the existing :80/:443 listeners they can already hit.