### PR TITLE
fix(monitoring): escape $ in thanos rules content for Compose substitution

### DIFF
--- a/terraform/portainer/stacks/thanos-rule.yml.tftpl
+++ b/terraform/portainer/stacks/thanos-rule.yml.tftpl
@@ -36,9 +36,15 @@ configs:
   # terraform/portainer/stacks/thanos-rules.yml (loaded via file() in
   # stacks.tf). Edit the rules file, terraform apply, then
   # ./scripts/portainer-redeploy.py thanos-rule to push.
+  #
+  # `replace(..., "$", "$$")` escapes single-dollar so Compose's
+  # variable substitution doesn't eat `$value` / `$labels.instance`
+  # before the rules reach the Prometheus template engine. Same trick
+  # the existing prometheus.yml.tftpl uses for its scrape configs.
+  # Memory: feedback_compose_configs_dollar_interpolation.md.
   thanos_rules:
     content: |
-      ${indent(6, thanos_rules_yml)}
+      ${indent(6, replace(thanos_rules_yml, "$", "$$"))}
 
 services:
   thanos-rule:


### PR DESCRIPTION
Quick follow-up to #49. The 5 rules deployed but the ruler crash-looped:

```text
template: __alert_*:1: missing value for command
template: __alert_*:3: unexpected "|" in command
```

Root cause: rules contain `{{ \$value | humanize1024 }}` etc. The rules YAML is inlined via Compose `configs.content:`, and Compose substitutes `\$VAR` / `\${VAR}` before mounting the file. No `value` or `labels.instance` env vars exist, so Compose substituted them to empty — leaving `{{  | humanize1024 }}` (missing pipeline value) and `{{ .instance }}` (fails parse).

Same problem the existing `prometheus.yml.tftpl` already solved with `replace(prometheus_config, "\$", "\$\$")`. Apply same escape to rules. Memory: `feedback_compose_configs_dollar_interpolation.md`.

Plan: 1 stack updated in-place. Deploy: `terraform apply` + `./scripts/portainer-redeploy.py thanos-rule`.