### PR TITLE
fix(monitoring): point thanos-rule --query at macvlan IP, not DNS alias

### DIFF
--- a/terraform/portainer/stacks/thanos-rule.yml.tftpl
+++ b/terraform/portainer/stacks/thanos-rule.yml.tftpl
@@ -68,8 +68,13 @@ services:
       - --label=region="local"
       # Query layer to evaluate rules against — go directly to thanos-query
       # on dockermaster (HA fan-out across both prometheus replicas + the
-      # store gateway).
-      - --query=thanos-query.servers-net:10902
+      # store gateway). Use the macvlan IP rather than DNS because the
+      # network's actual name is `docker-servers-net` (not `servers-net`,
+      # which is just the local alias inside this stack); the
+      # network-scoped FQDN `thanos-query.servers-net` would only resolve
+      # if Docker's embedded DNS knew the network by that local alias,
+      # which it doesn't.
+      - --query=192.168.59.26:10902
       # Both alertmanagers; gossip handles dedup.
       - --alertmanagers.url=http://192.168.59.27:9093
       - --alertmanagers.url=http://192.168.4.238:9093


### PR DESCRIPTION
Quick fix on top of #50. The 5 rules now load cleanly but every evaluation fails:

```text
err="dial tcp: lookup thanos-query.servers-net on 127.0.0.11:53: no such host"
```

Wrong network alias: `thanos-query.servers-net` was the network-scoped FQDN form from memory `feedback_docker_dns_network_scope.md`, but the network's actual name is `docker-servers-net` (`servers-net` is just the alias used INSIDE the compose stack's `networks:` block, not the external network name Docker DNS knows).

Use the macvlan IP `192.168.59.26` directly — same pattern thanos-query itself uses for its `--endpoint` flags. Plan: 1 stack updated in-place.