### PR TITLE
feat(monitoring): grafana dashboard for thanos & prometheus stack health

### DIFF
--- a/terraform/portainer/stacks.tf
+++ b/terraform/portainer/stacks.tf
@@ -1197,10 +1197,19 @@ resource "portainer_stack" "grafana" {
   # Dashboard JSONs in stacks/grafana-dashboards/*.json get auto-rendered
   # into Compose `configs:` blocks per file — no bind-mount, no manual scp.
   # Add a dashboard: drop a JSON file in that dir, re-run `terraform apply`.
+  #
+  # Subfolder convention: stacks/grafana-dashboards/ → Grafana folder
+  # "Homelab" (catch-all). stacks/grafana-dashboards-observability/ →
+  # folder "Observability" (Thanos/Prometheus/Alertmanager stack health).
+  # New subfolder = new dir + new map here + new provider in the .tftpl.
   stack_file_content = templatefile("${path.module}/stacks/grafana.yml.tftpl", {
     dashboards = {
       for f in fileset("${path.module}/stacks/grafana-dashboards", "*.json") :
       trimsuffix(f, ".json") => file("${path.module}/stacks/grafana-dashboards/${f}")
+    }
+    dashboards_observability = {
+      for f in fileset("${path.module}/stacks/grafana-dashboards-observability", "*.json") :
+      trimsuffix(f, ".json") => file("${path.module}/stacks/grafana-dashboards-observability/${f}")
     }
   })
 

--- a/terraform/portainer/stacks/grafana-dashboards-observability/thanos-prometheus.json
+++ b/terraform/portainer/stacks/grafana-dashboards-observability/thanos-prometheus.json
@@ -1,0 +1,1030 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Health + throughput overview for the Thanos + Prometheus + Alertmanager monitoring stack. Active alerts, sidecar shipping, compactor cycles, store gateway reads, ruler evaluations, query latency.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "thanos"
+      },
+      "description": "Prometheus targets in 'up' state across both replicas via Thanos dedup.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.85
+              },
+              {
+                "color": "green",
+                "value": 0.95
+              }
+            ]
+          },
+          "unit": "percentunit"
+        }
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "13.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "thanos"
+          },
+          "expr": "avg(up)",
+          "legendFormat": "Targets UP",
+          "refId": "A"
+        }
+      ],
+      "title": "Targets UP (avg)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "thanos"
+      },
+      "description": "Active alerts currently firing on either alertmanager.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "13.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "thanos"
+          },
+          "expr": "max(alertmanager_alerts{state=\"active\"})",
+          "legendFormat": "Active",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Alerts",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "thanos"
+      },
+      "description": "Active time series stored in each Prometheus replica's TSDB head.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "13.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "thanos"
+          },
+          "expr": "max by (instance) (prometheus_tsdb_head_series)",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Series (per replica)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "thanos"
+      },
+      "description": "Total bytes used in the MinIO 'thanos' bucket across both replicas (deduped via aggregation).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 500000000000
+              },
+              {
+                "color": "red",
+                "value": 800000000000
+              }
+            ]
+          },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "13.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "thanos"
+          },
+          "expr": "max(minio_cluster_usage_total_bytes)",
+          "legendFormat": "MinIO usage",
+          "refId": "A"
+        }
+      ],
+      "title": "MinIO Usage (cluster total)",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 100,
+      "panels": [],
+      "title": "Prometheus health",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "thanos"
+      },
+      "description": "Active series count over time per replica. Sudden drops can indicate target loss; sustained growth indicates new sources or cardinality drift.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth"
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "thanos"
+          },
+          "expr": "prometheus_tsdb_head_series",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Active series (TSDB head)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "thanos"
+      },
+      "description": "Scrape duration p99 per scrape job. Spikes suggest slow exporters or network jitter.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 5,
+            "lineInterpolation": "smooth"
+          },
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "thanos"
+          },
+          "expr": "histogram_quantile(0.99, sum by (job, le) (rate(prometheus_target_interval_length_seconds_bucket[5m])))",
+          "legendFormat": "p99 {{job}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Scrape interval p99 per job",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 101,
+      "panels": [],
+      "title": "Thanos sidecars (shipping)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "thanos"
+      },
+      "description": "Successful block uploads per sidecar. Expect ~30 per 24h per replica (one 2h block \u00d7 12 + retries).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth"
+          },
+          "unit": "ops"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "thanos"
+          },
+          "expr": "rate(thanos_shipper_uploads_total[5m])",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Sidecar upload rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "thanos"
+      },
+      "description": "Sidecar upload failures rate. Should be 0 in healthy state. Bucket-empty incident on 2026-04-25 \u2192 2026-05-09 showed this alarming for 13d straight; fixed via UID/mount changes in PRs #42 #43 #44.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.01
+              }
+            ]
+          },
+          "unit": "ops"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "thanos"
+          },
+          "expr": "rate(thanos_shipper_upload_failures_total[5m])",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Sidecar upload failures rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 102,
+      "panels": [],
+      "title": "Thanos compactor (downsample / retention)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "thanos"
+      },
+      "description": "Compaction iterations completed. Each iteration scans all blocks in the bucket and merges/downsamples eligible ones.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth"
+          },
+          "unit": "ops"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 24
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "thanos"
+          },
+          "expr": "rate(thanos_compact_iterations_total[15m])",
+          "legendFormat": "iterations",
+          "refId": "A"
+        }
+      ],
+      "title": "Compactor iteration rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "thanos"
+      },
+      "description": "Downsample iterations (5m + 1h resolutions). Should run regularly once enough blocks accumulate (>1d after first ingest).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth"
+          },
+          "unit": "ops"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 24
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "thanos"
+          },
+          "expr": "rate(thanos_compact_downsample_total[15m])",
+          "legendFormat": "downsample",
+          "refId": "A"
+        }
+      ],
+      "title": "Compactor downsample rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "thanos"
+      },
+      "description": "Blocks the compactor has marked for deletion in this cycle (retention enforcement: raw 90d, 5m 365d, 1h 730d).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth"
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 24
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "thanos"
+          },
+          "expr": "thanos_compact_blocks_marked_for_deletion_total",
+          "legendFormat": "marked",
+          "refId": "A"
+        }
+      ],
+      "title": "Blocks marked for deletion",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "id": 103,
+      "panels": [],
+      "title": "Thanos ruler + query",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "thanos"
+      },
+      "description": "Rule evaluations per second. Should track rules \u00d7 eval_interval (5 rules at 1m interval = ~0.083/s).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth"
+          },
+          "unit": "ops"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 33
+      },
+      "id": 40,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "thanos"
+          },
+          "expr": "rate(prometheus_rule_evaluations_total{instance=\"thanos-rule\"}[5m])",
+          "legendFormat": "evals/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Ruler evaluations rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "thanos"
+      },
+      "description": "Rule evaluation failures. Should be 0; spikes suggest the Querier is unreachable or rules reference missing metrics.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.01
+              }
+            ]
+          },
+          "unit": "ops"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 33
+      },
+      "id": 41,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "thanos"
+          },
+          "expr": "rate(prometheus_rule_evaluation_failures_total{instance=\"thanos-rule\"}[5m])",
+          "legendFormat": "failures/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Ruler evaluation failures",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "thanos"
+      },
+      "description": "Querier latency p50/p99. p99 spikes >5s usually mean a long-range query hitting cold-cache store-gw paths.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 5,
+            "lineInterpolation": "smooth"
+          },
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 33
+      },
+      "id": 42,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "thanos"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(http_request_duration_seconds_bucket{instance=\"thanos-query\",handler=\"/api/v1/query\"}[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "thanos"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket{instance=\"thanos-query\",handler=\"/api/v1/query\"}[5m])))",
+          "legendFormat": "p99",
+          "refId": "B"
+        }
+      ],
+      "title": "Query latency",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 41
+      },
+      "id": 104,
+      "panels": [],
+      "title": "Object storage (bucket ops)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "thanos"
+      },
+      "description": "Bucket operations (gets / puts / lists) per Thanos component. Reads from store-gw + compact, writes from sidecars + compact.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "unit": "ops"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 42
+      },
+      "id": 50,
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "thanos"
+          },
+          "expr": "sum by (instance, operation) (rate(thanos_objstore_bucket_operations_total[5m]))",
+          "legendFormat": "{{instance}} / {{operation}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Bucket operations rate (by component / op)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "thanos"
+      },
+      "description": "Bucket operation failures. Should be 0; if non-zero check MinIO health, network to the bucket endpoint, and the IAM svcaccount on minio-1/minio-2.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.01
+              }
+            ]
+          },
+          "unit": "ops"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 42
+      },
+      "id": 51,
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "thanos"
+          },
+          "expr": "sum by (instance, operation) (rate(thanos_objstore_bucket_operation_failures_total[5m]))",
+          "legendFormat": "{{instance}} / {{operation}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Bucket operation failures rate",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "tags": [
+    "thanos",
+    "prometheus",
+    "observability",
+    "homelab"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Thanos & Prometheus Infrastructure",
+  "uid": "thanos-prometheus-infra",
+  "version": 1,
+  "weekStart": ""
+}

--- a/terraform/portainer/stacks/grafana.yml.tftpl
+++ b/terraform/portainer/stacks/grafana.yml.tftpl
@@ -72,8 +72,23 @@ configs:
           allowUiUpdates: true
           options:
             path: /var/lib/grafana/dashboards
+        - name: observability
+          orgId: 1
+          folder: Observability
+          type: file
+          disableDeletion: false
+          editable: true
+          updateIntervalSeconds: 60
+          allowUiUpdates: true
+          options:
+            path: /var/lib/grafana/dashboards-observability
 %{ for name, content in dashboards ~}
   dashboard_${replace(name, "-", "_")}:
+    content: |
+      ${indent(6, replace(content, "$", "$$"))}
+%{ endfor ~}
+%{ for name, content in dashboards_observability ~}
+  obs_dashboard_${replace(name, "-", "_")}:
     content: |
       ${indent(6, replace(content, "$", "$$"))}
 %{ endfor ~}
@@ -133,6 +148,11 @@ services:
 %{ for name, _ in dashboards ~}
       - source: dashboard_${replace(name, "-", "_")}
         target: /var/lib/grafana/dashboards/${name}.json
+        mode: 0644
+%{ endfor ~}
+%{ for name, _ in dashboards_observability ~}
+      - source: obs_dashboard_${replace(name, "-", "_")}
+        target: /var/lib/grafana/dashboards-observability/${name}.json
         mode: 0644
 %{ endfor ~}
     expose:

--- a/terraform/portainer/stacks/thanos-rule.yml.tftpl
+++ b/terraform/portainer/stacks/thanos-rule.yml.tftpl
@@ -68,8 +68,13 @@ services:
       - --label=region="local"
       # Query layer to evaluate rules against — go directly to thanos-query
       # on dockermaster (HA fan-out across both prometheus replicas + the
-      # store gateway).
-      - --query=thanos-query.servers-net:10902
+      # store gateway). Use the macvlan IP rather than DNS because the
+      # network's actual name is `docker-servers-net` (not `servers-net`,
+      # which is just the local alias inside this stack); the
+      # network-scoped FQDN `thanos-query.servers-net` would only resolve
+      # if Docker's embedded DNS knew the network by that local alias,
+      # which it doesn't.
+      - --query=192.168.59.26:10902
       # Both alertmanagers; gossip handles dedup.
       - --alertmanagers.url=http://192.168.59.27:9093
       - --alertmanagers.url=http://192.168.4.238:9093


### PR DESCRIPTION
## Summary

Adds the first dashboard in a new **Observability** Grafana folder, separate from the existing "Homelab" catch-all. Surfaces the health of the monitoring stack itself — Thanos sidecars + store-gw + compactor + ruler + querier + Prometheus + Alertmanager + the MinIO bucket they all share.

## Panels (15 across 5 row groups)

| Row | Panels |
|---|---|
| **Header strip (4 stats)** | Targets UP avg · Active alerts · Active series per replica · MinIO bucket usage |
| **Prometheus health** | Active series over time · Scrape interval p99 per job |
| **Thanos sidecars** | Upload rate · Upload-failures rate _(annotated with the 13d outage and the PRs that fixed it)_ |
| **Thanos compactor** | Iteration rate · Downsample rate · Blocks marked for deletion |
| **Thanos ruler + query** | Eval rate · Eval failures · Query latency p50/p99 |
| **Object storage** | Bucket ops rate (by component/op, stacked) · Bucket op failures rate |

## File layout

```text
terraform/portainer/stacks/
├── grafana-dashboards/                    # → folder "Homelab"  (existing)
└── grafana-dashboards-observability/      # → folder "Observability"  (NEW)
    └── thanos-prometheus.json
```

`grafana.yml.tftpl` gets a second provisioning provider:

```yaml
providers:
  - name: homelab
    folder: Homelab
    options: { path: /var/lib/grafana/dashboards }
  - name: observability
    folder: Observability
    options: { path: /var/lib/grafana/dashboards-observability }
```

Future Observability dashboards: drop a `*.json` in the new dir, `terraform apply`, redeploy. The pattern scales to N folders by adding another `{ map / provider / loop }` triple in `stacks.tf` + `.tftpl`.

## Plan

```text
$ terraform plan
  # portainer_stack.grafana will be updated in-place
Plan: 0 to add, 1 to change, 0 to destroy.
```

## Deploy

```bash
cd terraform/portainer && terraform apply
./scripts/portainer-redeploy.py grafana
```

## Test plan

- [ ] `terraform apply` succeeds with `~ portainer_stack.grafana`.
- [ ] Grafana container UP after redeploy.
- [ ] Log in to `https://grafana.d.lcamaral.com/`, navigate to Dashboards → Observability folder exists with `Thanos & Prometheus Infrastructure` inside.
- [ ] All 15 panels render with live data:
  - Targets UP gauge shows ~98%+ (current state: 71/72 UP).
  - Active series per replica matches `prometheus_tsdb_head_series` query.
  - Sidecar upload rate non-zero for both `thanos-sidecar-1` and `thanos-sidecar-2`.
  - Compactor iteration + downsample rates non-zero.
  - Ruler evaluation rate ~0.083/s (5 rules at 1m).
  - Bucket operations panel shows reads (store-gw + compact) + writes (sidecars + compact).
- [ ] No regression on the existing 11 "Homelab" folder dashboards.